### PR TITLE
bugfix seq calculation if transf. method for CONSERV is set

### DIFF
--- a/esm_runscripts/oasis.py
+++ b/esm_runscripts/oasis.py
@@ -45,9 +45,8 @@ class oasis:
         # if a transformation method for CONSERV (e.g. GLOBAL) is set below, 
         # increase seq (=number of lines describing the transformation) by 1
         seq = int(direction.get("seq", "2"))
-        if transformation.get("postprocessing",None):
-           if transformation["postprocessing"].get("conserv",None):
-              if transformation["postprocessing"]["conserv"].get("method", None): seq += 1
+        if transformation.get("postprocessing", {}).get("conserv", {}).get("method"):
+            seq += 1
 
         self.namcouple += [right + " " + left + " " + str(nb) + " " + str(time_step) + " " + str(seq) + " " + str(restart_file) + " " + export_mode]
         if lgrid and rgrid:

--- a/esm_runscripts/oasis.py
+++ b/esm_runscripts/oasis.py
@@ -37,12 +37,17 @@ class oasis:
 
         if lresume == False:
             lag = str(0)
-            seq = str(2)
             export_mode = "EXPOUT"
         else:
             lag = direction.get("lag", "0")
-            seq = direction.get("seq", "2")
             export_mode = "EXPORTED"
+         
+        # if a transformation method for CONSERV (e.g. GLOBAL) is set below, 
+        # increase seq (=number of lines describing the transformation) by 1
+        seq = int(direction.get("seq", "2"))
+        if transformation.get("postprocessing",None):
+           if transformation["postprocessing"].get("conserv",None):
+              if transformation["postprocessing"]["conserv"].get("method", None): seq += 1
 
         self.namcouple += [right + " " + left + " " + str(nb) + " " + str(time_step) + " " + str(seq) + " " + str(restart_file) + " " + export_mode]
         if lgrid and rgrid:


### PR DESCRIPTION
Now namcouple works for the following and we get a 4 in front of flxatmos instead of 3:
```
TotRain OTotRain 16 10800 4 flxatmos EXPOUT
192 96 722 511 atmo opac LAG=0
P 0 P 2
LOCTRANS SCRIPR MAPPING CONSERV
INSTANT
CONSERV D SCALAR LATITUDE 40 FRACNNEI FIRST
rmp_atmo_to_opac_CONSERV_FRACNNEI_D_T63_ORCA05.nc src
GLOBAL
```