### PR TITLE
allows for a debugger to be turned on during object init

### DIFF
--- a/esm_runscripts/compute.py
+++ b/esm_runscripts/compute.py
@@ -277,7 +277,7 @@ class compute(jobclass.jobclass):
             os.system( restart_command )
 
             gconfig["profile"] = False
-            compute.end_it_all(config)
+            compute.end_it_all(config, silent=True)
 
 
     @staticmethod

--- a/esm_runscripts/esm_sim_objects.py
+++ b/esm_runscripts/esm_sim_objects.py
@@ -45,6 +45,8 @@ class SimulationSetup(object):
             self.command_line_config = command_line_config
         if not user_config:
             user_config = self.get_user_config_from_command_line(command_line_config)
+        if user_config["general"].get("debug_obj_init", False):
+            import pdb; pdb.set_trace()
         self.get_total_config_from_user_config(user_config)
 
     def __call__(self, *args, **kwargs):

--- a/esm_runscripts/jobclass.py
+++ b/esm_runscripts/jobclass.py
@@ -281,7 +281,7 @@ class jobclass:
             for line in timing_info:
                 print(line)
         if not silent:
-        print("Exiting entire Python process!")
+            print("Exiting entire Python process!")
         sys.exit()
 
 

--- a/esm_runscripts/jobclass.py
+++ b/esm_runscripts/jobclass.py
@@ -275,11 +275,12 @@ class jobclass:
 
 
     @staticmethod
-    def end_it_all(config):
+    def end_it_all(config, silent=False):
         import sys
         if config["general"]["profile"]:
             for line in timing_info:
                 print(line)
+        if not silent:
         print("Exiting entire Python process!")
         sys.exit()
 


### PR DESCRIPTION
Allows for the `pdb` debugger to be turned on during object creation from the general section of the config