### PR TITLE
Fixup for logfiles

### DIFF
--- a/esm_runscripts/esm_sim_objects.py
+++ b/esm_runscripts/esm_sim_objects.py
@@ -687,7 +687,7 @@ class SimulationSetup(object):
             last_jobid = "UNKNOWN"
             if called_from == "compute":
                 with open(self.config["general"]["experiment_log_file"], "r") as logfile:
-                    lastline = logfile.readlines()[-1]
+                    lastline = [l for l in logfile.readlines() if "compute" in l and "start" in l][-1]
                     last_jobid = lastline.split(" - ")[0].split()[-1]
             #monitoring_events=self.assemble_monitoring_events()
 

--- a/esm_runscripts/esm_sim_objects.py
+++ b/esm_runscripts/esm_sim_objects.py
@@ -684,6 +684,11 @@ class SimulationSetup(object):
             monitor_file.write("tidy job initialized \n")
             monitor_file.write("attaching to process " + str(self.config["general"]["launcher_pid"]) + " \n")
             monitor_file.write("Called from a " + called_from + "job \n")
+            last_jobid = "UNKNOWN"
+            if called_from == "compute":
+                with open(self.config["general"]["experiment_log_file"], "r") as logfile:
+                    lastline = logfile.readlines()[-1]
+                    last_jobid = lastline.split(" - ")[0].split()[-1]
             #monitoring_events=self.assemble_monitoring_events()
 
             filetypes=["log", "mon", "outdata", "restart_out"]
@@ -699,7 +704,7 @@ class SimulationSetup(object):
                     called_from,
                     str(self.config["general"]["run_number"]),
                     str(self.config["general"]["current_date"]),
-                    str(self.config["general"]["jobid"]),
+                    last_jobid,
                     "- done"])
             # Tell the world you're cleaning up:
             jobclass.jobclass.write_to_log(self.config, [


### PR DESCRIPTION
Currently, the log file has the incorrect ID number when logging compute jobs:

```
Wed Jun  3 13:05:27 2020 : # Beginning of Experiment bench01
Wed Jun  3 13:05:27 2020 : compute 1 2000-01-01T00:00:00 168245 - start
Wed Jun  3 14:00:24 2020 : compute 1 2000-01-01T00:00:00 6104316 - done
Wed Jun  3 14:00:24 2020 : tidy_and_resubmit 1 2000-01-01T00:00:00 6104316 - start
Wed Jun  3 14:07:52 2020 : tidy_and_resubmit 1 2000-01-01T00:00:00 6104316 - done
Wed Jun  3 14:07:53 2020 : compute 2 2001-01-01T00:00:00 6104316 - start
Wed Jun  3 14:36:44 2020 : compute 2 2001-01-01T00:00:00 6104428 - done
Wed Jun  3 14:36:44 2020 : tidy_and_resubmit 2 2001-01-01T00:00:00 6104428 - start
Wed Jun  3 14:36:57 2020 : tidy_and_resubmit 2 2001-01-01T00:00:00 6104428 - done
Wed Jun  3 14:36:58 2020 : compute 3 2002-01-01T00:00:00 6104428 - start
Wed Jun  3 15:04:47 2020 : compute 3 2002-01-01T00:00:00 6104476 - done
Wed Jun  3 15:04:47 2020 : tidy_and_resubmit 3 2002-01-01T00:00:00 6104476 - start
Wed Jun  3 15:05:08 2020 : tidy_and_resubmit 3 2002-01-01T00:00:00 6104476 - done
Wed Jun  3 15:05:08 2020 : compute 4 2003-01-01T00:00:00 6104476 - start
Wed Jun  3 15:33:18 2020 : compute 4 2003-01-01T00:00:00 6104523 - done
Wed Jun  3 15:33:18 2020 : tidy_and_resubmit 4 2003-01-01T00:00:00 6104523 - start
Wed Jun  3 15:33:35 2020 : tidy_and_resubmit 4 2003-01-01T00:00:00 6104523 - done
Wed Jun  3 15:33:36 2020 : compute 5 2004-01-01T00:00:00 6104523 - start
```

This merge request fixes that by figuring out what the last compute job was and getting out the job id number.