### PR TITLE
Hotfix/time step from another model

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "4.1.4"
+__version__ = "4.1.5"
 
 from .esm_sim_objects import *
 from .esm_batch_system import *

--- a/esm_runscripts/esm_sim_objects.py
+++ b/esm_runscripts/esm_sim_objects.py
@@ -501,6 +501,9 @@ class SimulationSetup(object):
         for model in self.config["general"]["valid_model_names"]:
             if "time_step" in self.config[model] and not (type(self.config[model]["time_step"]) == str and "${" in self.config[model]["time_step"]):
                 self.config[model]["prev_date"] = self.current_date - (0, 0, 0, 0, 0, int(self.config[model]["time_step"]))
+            elif "time_step" in self.config[model] and (type(self.config[model]["time_step"]) == str and "${" in self.config[model]["time_step"]):
+                dt = esm_parser.find_variable(model,self.config[model]["time_step"],self.config,[],[])
+                self.config[model]["prev_date"] = self.current_date - (0, 0, 0, 0, 0, int(dt))
             else:
                 self.config[model]["prev_date"] = self.current_date
             if self.config[model]["lresume"] == True and self.config["general"]["run_number"] == 1:

--- a/esm_runscripts/esm_sim_objects.py
+++ b/esm_runscripts/esm_sim_objects.py
@@ -498,11 +498,18 @@ class SimulationSetup(object):
 
 
     def set_prev_date(self):
+        """Sets several variables relevant for the previous date. Loops over all models in ``valid_model_names``, and sets model variables for:
+        * ``prev_date``
+        * ``parent_expid``
+        * ``parent_date``
+        * ``parent_restart_dir``
+        """
         for model in self.config["general"]["valid_model_names"]:
-            if "time_step" in self.config[model] and not (type(self.config[model]["time_step"]) == str and "${" in self.config[model]["time_step"]):
+            if "time_step" in self.config[model] and not (isinstance(self.config[model]["time_step"], str) and "${" in self.config[model]["time_step"]):
                 self.config[model]["prev_date"] = self.current_date - (0, 0, 0, 0, 0, int(self.config[model]["time_step"]))
-            elif "time_step" in self.config[model] and (type(self.config[model]["time_step"]) == str and "${" in self.config[model]["time_step"]):
-                dt = esm_parser.find_variable(model,self.config[model]["time_step"],self.config,[],[])
+            # NOTE(PG, MAM): Here we check if the time step still has a variable which might be set in a different model, and resolve this case
+            elif "time_step" in self.config[model] and (isinstance(self.config[model]["time_step"], str) and "${" in self.config[model]["time_step"]):   
+                dt = esm_parser.find_variable(model, self.config[model]["time_step"], self.config, [], [])
                 self.config[model]["prev_date"] = self.current_date - (0, 0, 0, 0, 0, int(dt))
             else:
                 self.config[model]["prev_date"] = self.current_date

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.4
+current_version = 4.1.5
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="4.1.4",
+    version="4.1.5",
     zip_safe=False,
 )


### PR DESCRIPTION
I defined REcoM's time-step in the `fesom-recom.yaml` as:

```
recom:
    time_step: "${fesom.time_step}"
```

I did this so that the REcoM time step would be always the same as fesom's unless the user defines a specific time step for REcoM.

However, this leads to problems with the calculation of the `prev_date` for REcoM as integers are expected but not variables at the point in `esm_sim_object.py` where `prev_date` is calculated, and `time_step` have not yet been parsed at that point. This merge is to correct that, so that `esm_sim_object.py` can search for the `time_step` at that point.