### PR TITLE
Hotfix/parent restart dir

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "4.1.4"
+__version__ = "4.1.5"
 
 from .esm_sim_objects import *
 from .esm_batch_system import *

--- a/esm_runscripts/esm_sim_objects.py
+++ b/esm_runscripts/esm_sim_objects.py
@@ -501,6 +501,9 @@ class SimulationSetup(object):
         for model in self.config["general"]["valid_model_names"]:
             if "time_step" in self.config[model] and not (type(self.config[model]["time_step"]) == str and "${" in self.config[model]["time_step"]):
                 self.config[model]["prev_date"] = self.current_date - (0, 0, 0, 0, 0, int(self.config[model]["time_step"]))
+            elif "time_step" in self.config[model] and (type(self.config[model]["time_step"]) == str and "${" in self.config[model]["time_step"]):
+                dt = esm_parser.find_variable(model,self.config[model]["time_step"],self.config,[],[])
+                self.config[model]["prev_date"] = self.current_date - (0, 0, 0, 0, 0, int(dt))
             else:
                 self.config[model]["prev_date"] = self.current_date
             if self.config[model]["lresume"] == True and self.config["general"]["run_number"] == 1:

--- a/esm_runscripts/esm_sim_objects.py
+++ b/esm_runscripts/esm_sim_objects.py
@@ -355,12 +355,12 @@ class SimulationSetup(object):
                     user_lresume = config[model]["lresume"]
                 else:
                     user_lresume = False
-                if type(user_lresume) == str:
+                if isinstance(user_lresume, str):
                     if user_lresume == "0" or user_lresume.upper() == "FALSE":
                         user_lresume = False
                     elif user_lresume == "1" or user_lresume.upper() == "TRUE":
                         user_lresume = True
-                elif type(user_lresume) == int:
+                elif isinstance(user_lresume, int):
                     if user_lresume == 0:
                         user_lresume = False
                     elif user_lresume == 1:
@@ -508,11 +508,15 @@ class SimulationSetup(object):
             if "time_step" in self.config[model] and not (isinstance(self.config[model]["time_step"], str) and "${" in self.config[model]["time_step"]):
                 self.config[model]["prev_date"] = self.current_date - (0, 0, 0, 0, 0, int(self.config[model]["time_step"]))
             # NOTE(PG, MAM): Here we check if the time step still has a variable which might be set in a different model, and resolve this case
-            elif "time_step" in self.config[model] and (isinstance(self.config[model]["time_step"], str) and "${" in self.config[model]["time_step"]):   
+            elif "time_step" in self.config[model] and (isinstance(self.config[model]["time_step"], str) and "${" in self.config[model]["time_step"]):
                 dt = esm_parser.find_variable(model, self.config[model]["time_step"], self.config, [], [])
                 self.config[model]["prev_date"] = self.current_date - (0, 0, 0, 0, 0, int(dt))
             else:
                 self.config[model]["prev_date"] = self.current_date
+            # Check if lresume contains a variable which might be set in a different model, and resolve this case
+            if "lresume" in self.config[model] and isinstance(self.config[model]["lresume"], str) and "${" in self.config[model]["lresume"]:
+                lr = esm_parser.find_variable(model, self.config[model]["lresume"], self.config, [], [])
+                self.config[model]["lresume"] = eval(lr)
             if self.config[model]["lresume"] == True and self.config["general"]["run_number"] == 1:
                 self.config[model]["parent_expid"] = self.config[model][
                     "ini_parent_exp_id"
@@ -732,7 +736,7 @@ class SimulationSetup(object):
                     method = "warn"
                     frequency = 60
                     message = "keyword " + trigger + " detected, watch out"
-                    if type (self.config[model]["check_error"][trigger] ) == dict:
+                    if isinstance(self.config[model]["check_error"][trigger], dict):
                         if "file" in  self.config[model]["check_error"][trigger]:
                             search_file = self.config[model]["check_error"][trigger]["file"]
                             if search_file == "stdout" or search_file == "stderr":
@@ -749,7 +753,7 @@ class SimulationSetup(object):
                                 frequency = int(frequency)
                             except:
                                 frequency = 60
-                    elif type( self.config[model]["check_error"][trigger] ) == str:
+                    elif isinstance(self.config[model]["check_error"][trigger], str) :
                         pass
                     else:
                         continue

--- a/esm_runscripts/esm_sim_objects.py
+++ b/esm_runscripts/esm_sim_objects.py
@@ -498,11 +498,18 @@ class SimulationSetup(object):
 
 
     def set_prev_date(self):
+        """Sets several variables relevant for the previous date. Loops over all models in ``valid_model_names``, and sets model variables for:
+        * ``prev_date``
+        * ``parent_expid``
+        * ``parent_date``
+        * ``parent_restart_dir``
+        """
         for model in self.config["general"]["valid_model_names"]:
-            if "time_step" in self.config[model] and not (type(self.config[model]["time_step"]) == str and "${" in self.config[model]["time_step"]):
+            if "time_step" in self.config[model] and not (isinstance(self.config[model]["time_step"], str) and "${" in self.config[model]["time_step"]):
                 self.config[model]["prev_date"] = self.current_date - (0, 0, 0, 0, 0, int(self.config[model]["time_step"]))
-            elif "time_step" in self.config[model] and (type(self.config[model]["time_step"]) == str and "${" in self.config[model]["time_step"]):
-                dt = esm_parser.find_variable(model,self.config[model]["time_step"],self.config,[],[])
+            # NOTE(PG, MAM): Here we check if the time step still has a variable which might be set in a different model, and resolve this case
+            elif "time_step" in self.config[model] and (isinstance(self.config[model]["time_step"], str) and "${" in self.config[model]["time_step"]):   
+                dt = esm_parser.find_variable(model, self.config[model]["time_step"], self.config, [], [])
                 self.config[model]["prev_date"] = self.current_date - (0, 0, 0, 0, 0, int(dt))
             else:
                 self.config[model]["prev_date"] = self.current_date

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.4
+current_version = 4.1.5
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="4.1.4",
+    version="4.1.5",
     zip_safe=False,
 )


### PR DESCRIPTION
`parent_restart_dir` was not well defined on a restart runscript if the model `lresume` was a variable depending on another model.

In the old `esm_sim_objects`:
```
516             if self.config[model]["lresume"] == True and self.config["general"]["run_number"] == 1:
517                 self.config[model]["parent_expid"] = self.config[model][
518                     "ini_parent_exp_id"
519                 ]
520                 if "parent_date" not in self.config[model]:
521                     self.config[model]["parent_date"] = self.config[model][
522                         "ini_parent_date"
523                     ]
524                 self.config[model]["parent_restart_dir"] = self.config[model][
525                     "ini_restart_dir"
526                 ]
527             else:
528                 self.config[model]["parent_expid"] = self.config["general"][
529                     "expid"
530                 ]
531                 if "parent_date" not in self.config[model]:
532                     self.config[model]["parent_date"] = self.config[model][
533                         "prev_date"
534                     ]
535                 self.config[model]["parent_restart_dir"] = self.config[model][
536                     "experiment_restart_in_dir"
537                 ]
```
The following example is for a restart simulation with `echam` and the problems will take place for `jsbach` and `hdmodel`. The first condition `if self.config[model]["lresume"] == True and self.config["general"]["run_number"] == 1:` does not apply for `jsbach` as `self.config[model]["lresume"]`  is not true but it's `'${echam.lresume}'` (that is defined in the `jsbach.inherit.yaml` file). This means it jumps to the `else` for `jsbach` and `hdmodel` and here `parent_restart_dir` is defined as `experiment_restart_in_dir`, no matter what you have defined as `ini_restart_dir`  or `parent_restart_dir`  in the `jsbach.inherit.yaml`.

The issue was solved by adding an if before this block that checks if lresume is a variable and it it is it solves it before entering in the problematic `if`.

Additionally, conditions of the shape `type(object) == type` have been changed to `isinstance(object, type)`.

This is part of a few bug fixes to solve issue https://github.com/esm-tools/esm_tools/issues/77.