### PR TITLE
Hotfix/fix broken fileglobbing

### DIFF
--- a/esm_runscripts/filelists.py
+++ b/esm_runscripts/filelists.py
@@ -144,8 +144,8 @@ def globbing(config):
                         del config[model][filetype + "_sources"][descr]
                         all_filenames = glob.glob(filename)
                         running_index = 0
+
                         for new_filename in all_filenames:
-                            
                             newdescr = descr + "_glob_" + str(running_index)
                             config[model][filetype + "_sources"][newdescr] = new_filename
                             if config[model][filetype +  "_targets"][descr] == filename: #source and target are identical if autocompleted
@@ -174,7 +174,13 @@ def target_subfolders(config):
                             sys.exit(-1)
                         if "*" in filename:
                             source_filename = os.path.basename(config[model][filetype + "_sources"][descr])
-                            config[model][filetype + "_targets"][descr] = filename.replace("*", source_filename)
+                            # directory wildcards are given as /*, wildcards in filenames are handled 
+                            # in routine 'globbing' above, if we don't check here, wildcards are handled twice
+                            # for files and hence filenames of e.g. restart files are screwed up.
+                            if filename.endswith("/*"):
+                                config[model][filetype + "_targets"][descr] = filename.replace("*", source_filename)
+                            else:
+                                config[model][filetype + "_targets"][descr] = source_filename
                         elif filename.endswith("/"):
                             source_filename = os.path.basename(config[model][filetype + "_sources"][descr])
                             config[model][filetype + "_targets"][descr] = filename + source_filename


### PR DESCRIPTION
This is essential for FOCI. The current version destroys the filenames if globbing is used.