### PR TITLE
added a better exception handling to jobclass.py -> find_correct_source

### DIFF
--- a/esm_runscripts/jobclass.py
+++ b/esm_runscripts/jobclass.py
@@ -305,6 +305,23 @@ class jobclass:
                     return fname
                 else:
                     continue
+                
+            # Deniz: added error checking. Sometimes file_source becomes a dictionary
+            # instead of a string.
+            import pathlib
+            if not isinstance(file_source, str) or not instance(file_source, pathlib.Path):
+                print("==============================================")
+                print("  ERROR: file_source is not of type string or Path.")
+                print("         Exiting the program")
+                print("  - file_source: \n {}".format(file_source))
+                print()
+                print("  - type(file_source) : {}".format(type(file_source)))
+                print("==============================================")
+                raise TypeError("file_source does not have the correct type")
+
+                #import sys
+                #sys.exit(-1)
+
         return file_source
 
 


### PR DESCRIPTION
Sometimes the **forcing_source** is a dictionary and esm_runscript ends with a cryptic error like:

>   File "/sw/rhel6-x64/conda/anaconda3-bleeding_edge/lib/python3.6/posixpath.py", line 146, in basename
>     p = os.fspath(p)
> TypeError: expected str, bytes or os.PathLike object, not dict

I added a more explanatory error message with an Exception so that the user can understand what went wrong. So, it now does this:

> ==============================================
>   ERROR: file_source is not of type string or Path.
>          Exiting the program
>   - file_source:
>  {'/pool/data/ECHAM6/input/r0007/T127/aero/T127_aeropt_kinne_sw_b14_fin_1865.nc': {'to': 1864}, '/pool/data/ECHAM6/input/r0007/T127/aero/T127_aeropt_kinne_sw_b14_fin_2000.nc': {'from': 1865, 'to': 2000}}
> 
>   - type(file_source) : <class 'dict'>
> ==============================================
> 
> Traceback (most recent call last):
>   File "/pf/a/a271096/.local/bin/esm_runscripts", line 11, in <module>
>     load_entry_point('esm-runscripts', 'console_scripts', 'esm_runscripts')()
>   File "/mnt/lustre01/pf/a/a271096/esm_all_packages/esm_runscripts/esm_runscripts/cli.py", line 168, in main
>     Setup()
>   File "/mnt/lustre01/pf/a/a271096/esm_all_packages/esm_runscripts/esm_runscripts/esm_sim_objects.py", line 54, in __call__
>     self.compute(*args, **kwargs)
>   File "/mnt/lustre01/pf/a/a271096/esm_all_packages/esm_runscripts/esm_runscripts/esm_sim_objects.py", line 79, in compute
>     Compute = compute(self.config)
>   File "/mnt/lustre01/pf/a/a271096/esm_all_packages/esm_runscripts/esm_runscripts/compute.py", line 13, in __init__
>     self.all_files_to_copy = self.assemble_file_lists(config, self.relevant_files)
>   File "/mnt/lustre01/pf/a/a271096/esm_all_packages/esm_runscripts/esm_runscripts/jobclass.py", line 40, in assemble_file_lists
>     self.really_assemble_file_list(config, model, filetypes)
>   File "/mnt/lustre01/pf/a/a271096/esm_all_packages/esm_runscripts/esm_runscripts/jobclass.py", line 244, in really_assemble_file_list
>     source_name=self.find_correct_source(file_source, year)
>   File "/mnt/lustre01/pf/a/a271096/esm_all_packages/esm_runscripts/esm_runscripts/jobclass.py", line 314, in find_correct_source
>     raise TypeError("file_source does not have the correct type")
> TypeError: file_source does not have the correct type
