### PR TITLE
Feature/cleanup run dir

### DIFF
--- a/esm_runscripts/esm_sim_objects.py
+++ b/esm_runscripts/esm_sim_objects.py
@@ -835,24 +835,78 @@ class SimulationSetup(object):
     # @staticmethod
     def clean_run_dir(self, config):
         """
-        This plugin allows you to clean up the ``run_${DATE}`` folder. The
-        cleanup files are specified in the config ``general`` section as
-        follows (documentation follows order of code as it is executed):
+        This plugin allows you to clean up the ``run_${DATE}`` folders.
+        To do that you can use the following variables under the
+        ``general`` section of your runscript (documentation follows order
+        of code as it is executed):
 
-        * ``general.clean_this_rundir``: (bool) Removes the entire run
-          directory.
+        * ``clean_runs``: **This is the most important variable for most
+          users**. It can take the following values:
+            * ``True``: removes the ``run_`` directory after each run
+              (**overrides every other** ``clean_`` **option**).
 
-        * ``general.clean_old_rundirs_except``: (int) Removes the entire run
-          directory except for the last <x> runs
+            * ``False``: does not remove any ``run_`` directory (default)
+              if no ``clean_`` variable is defined.
 
-        * ``general.clean_old_rundirs_keep_every``: (int) Removes the entire
-          run directory except every <x>th run
+            * ``<int>``: giving an integer as a value results in deleting
+              the ``run_`` folders except for the last <int> runs
+              (recommended option as it allows for debugging of crashed
+              simulations).
 
-        * ``general.clean_<filetype>_dir``: (bool) Erases the run directory
-          for a specific filetype
+          .. Note::
+             ``clean_runs: (bool)`` is incompatible with
+             ``clean_this_rundir`` and ``clean_runs: (int)`` is incompatible
+             with ``clean_old_rundirs_except`` (an error will be raised
+             after the end of the first simulation). The functionality of
+             ``clean_runs`` variable **alone will suffice most of the
+             standard user requirements**. If finer tunning for the removal
+             of ``run_`` directories is required you can used the following
+             variables instead of ``clean_runs``.
 
-        * ``general.clean_size``: (int or float) Erases all files with size
-          greater than ``clean_size``, must be specified in bytes!
+        * ``clean_this_rundir``: (bool) Removes the entire run directory
+          (equivalent to ``clean_runs: (bool)``). ``clean_this_rundir: True``
+          **overrides every other** ``clean_`` **option**.
+
+        * ``clean_old_rundirs_except``: (int) Removes the entire run
+          directory except for the last <x> runs (equivalent to
+          ``clean_runs: (int)``).
+
+        * ``clean_old_rundirs_keep_every``: (int) Removes the entire
+          run directory except every <x>th run. Compatible with
+          ``clean_old_rundirs_except`` or ``clean_runs: (int)``.
+
+        * ``clean_<filetype>_dir``: (bool) Erases the run directory
+          for a specific filetype. Compatible with all the other options.
+
+        * ``clean_size``: (int or float) Erases all files with size
+          greater than ``clean_size``, must be specified in bytes! Compatible
+          with all the other options.
+
+        Example
+        -------
+
+        To delete all the ``run_`` directories in your experiment include this
+        into your runscript:
+
+        .. code-block:: yaml
+
+           general:
+                   clean_runs: True
+
+        To keep the last 2 ``run_`` directories:
+
+        .. code-block:: yaml
+
+           general:
+                   clean_runs: 2
+
+        To keep the last 2 runs and every 5 runs:
+
+        .. code-block:: yaml
+
+           general:
+                   clean_old_rundirs_except: 2
+                   clean_old_rundirs_keep_every: 5
         """
         self._clean_run_determine_user_choice(config)
         self._clean_this_rundir(config)

--- a/esm_runscripts/esm_sim_objects.py
+++ b/esm_runscripts/esm_sim_objects.py
@@ -773,11 +773,75 @@ class SimulationSetup(object):
         * ``general.remove_size``: (int or float) Erases all files with size
           greater than ``remove_size``, must be specified in bytes!
         """
+        self._remove_run_determine_user_choice(config)
         self._remove_this_rundir(config)
         self._remove_old_rundirs_except(config)
         self._remove_old_runs_filetypes(config)
         self._remove_old_runs_size(config)
         return config
+
+
+    def _remove_run_determine_user_choice(self, config):
+        """
+        Determine user choice from a simple switch.
+
+        The user sets::
+
+        general:
+            remove_runs: <x>
+
+        where ``x`` can be one of:
+
+        * ``True`` Removes the current run dir
+        * ``False`` Keeps run dir
+        * ``int`` (must be >= 0) keep last ``x`` run dirs
+        """
+        user_remove = config["general"].get("remove_runs")
+        # TODO(PG): It might be nice if these sorts of checks happened earlier
+        # in the job, before it even gets to this function
+        if isinstance(user_remove, bool):
+            if "remove_this_run" not in config["general"]:
+                config["general"]["remove_this_run"] = user_remove
+            else:
+                print("------------------------------------------")
+                print("You have set both in your config:")
+                print()
+                print("general:")
+                print("    remove_this_run: ", config["general"]["remove_this_run"])
+                print("    remove_runs: ", user_remove)
+                print()
+                print("Please only use one of these!")
+                print("------------------------------------------")
+                sys.exit(1)
+        elif isinstance(user_remove, int):
+            if "remove_old_rundirs_except" not in config["general"]:
+                config["general"]["remove_old_rundirs_except"] = user_remove
+            else:
+                print("------------------------------------------")
+                print("You have set both in your config:")
+                print()
+                print("general:")
+                print("    remove_old_rundirs_except: ", config["general"]["remove_old_rundirs_except"])
+                print("    remove_runs: ", user_remove)
+                print()
+                print("Please only use one of these!")
+                print("------------------------------------------")
+                sys.exit(1)
+        else:
+            print("------------------------------------------")
+            print("Type Error!")
+            print("You have set this in your config:")
+            print("general:")
+            print("    remove_runs: ", user_remove)
+            print()
+            print("This is of type: ", type(user_remove))
+            print("However, only the following types are valid:")
+            print("   * boolean")
+            print("   * integer (greater or equal to 0!)")
+            print("Please correct that")
+            print("------------------------------------------")
+            sys.exit(1)
+
 
     def _remove_this_rundir(self, config):
         if config['general'].get("remove_this_rundir", False):

--- a/esm_runscripts/esm_sim_objects.py
+++ b/esm_runscripts/esm_sim_objects.py
@@ -799,15 +799,17 @@ class SimulationSetup(object):
         user_clean = config["general"].get("clean_runs")
         # TODO(PG): It might be nice if these sorts of checks happened earlier
         # in the job, before it even gets to this function
+        if not user_clean:
+            return  # Skip the rest of the function
         if isinstance(user_clean, bool):
-            if "clean_this_run" not in config["general"]:
-                config["general"]["clean_this_run"] = user_clean
+            if "clean_this_rundir" not in config["general"]:
+                config["general"]["clean_this_rundir"] = user_clean
             else:
                 print("------------------------------------------")
                 print("You have set both in your config:")
                 print()
                 print("general:")
-                print("    clean_this_run: ", config["general"]["clean_this_run"])
+                print("    clean_this_rundir: ", config["general"]["clean_this_rundir"])
                 print("    clean_runs: ", user_clean)
                 print()
                 print("Please only use one of these!")

--- a/esm_runscripts/esm_sim_objects.py
+++ b/esm_runscripts/esm_sim_objects.py
@@ -968,7 +968,10 @@ class SimulationSetup(object):
                 print("<x> **MUST** be an integer greater than 1!")
                 sys.exit(1)
             runs_to_keep_via_end_select = all_run_folders_in_experiment[-number_rundirs_to_keep:]
-        runs_to_keep = set(runs_to_keep_via_keepevery + runs_to_keep_via_end_select)
+        if  number_rundirs_keep_every or number_rundirs_to_keep:
+            runs_to_keep = set(runs_to_keep_via_keepevery + runs_to_keep_via_end_select)
+        else:
+            runs_to_keep = set(all_run_folders_in_experiment)
         runs_to_clean = set(all_run_folders_in_experiment) - runs_to_keep
         for run in list(runs_to_clean):
             rm_r(run)

--- a/esm_runscripts/esm_sim_objects.py
+++ b/esm_runscripts/esm_sim_objects.py
@@ -218,7 +218,8 @@ class SimulationSetup(object):
         """
         Calls post processing routines for this run.
         """
-        with open(
+        with open( # TODO: this will be deleted by the cleanup function
+                   # maybe change its location to the general experiment folder?
             self.config["general"]["thisrun_scripts_dir"] +
             "/" +
             self.config["general"]["expid"] +
@@ -966,7 +967,7 @@ class SimulationSetup(object):
                 print("-------------------------------------------------------------")
                 print("<x> **MUST** be an integer greater than 1!")
                 sys.exit(1)
-            runs_to_keep_via_end_select = all_run_folders_in_experiment[:-number_rundirs_to_keep]
+            runs_to_keep_via_end_select = all_run_folders_in_experiment[-number_rundirs_to_keep:]
         runs_to_keep = set(runs_to_keep_via_keepevery + runs_to_keep_via_end_select)
         runs_to_clean = set(all_run_folders_in_experiment) - runs_to_keep
         for run in list(runs_to_clean):
@@ -1006,7 +1007,7 @@ class SimulationSetup(object):
     def assemble_error_list(self):
         gconfig = self.config["general"]
         known_methods = ["warn", "kill"]
-        stdout = gconfig["thisrun_scripts_dir"] + "/" +  gconfig["expid"] + "_compute_" + gconfig["run_datestamp"] + "_" + gconfig["jobid"] + ".log"
+        stdout = gconfig["experiment_dir"] + "/scripts/" +  gconfig["expid"] + "_compute_" + gconfig["run_datestamp"] + "_" + gconfig["jobid"] + ".log"
 
         error_list = [("error", stdout, "warn", 60, 60, "keyword error detected, watch out")]
 

--- a/esm_runscripts/esm_sim_objects.py
+++ b/esm_runscripts/esm_sim_objects.py
@@ -799,7 +799,7 @@ class SimulationSetup(object):
         user_clean = config["general"].get("clean_runs")
         # TODO(PG): It might be nice if these sorts of checks happened earlier
         # in the job, before it even gets to this function
-        if not user_clean:
+        if user_clean is None:
             return  # Skip the rest of the function
         if isinstance(user_clean, bool):
             if "clean_this_rundir" not in config["general"]:

--- a/esm_runscripts/esm_sim_objects.py
+++ b/esm_runscripts/esm_sim_objects.py
@@ -758,37 +758,37 @@ class SimulationSetup(object):
         cleanup files are specified in the config ``general`` section as
         follows (documentation follows order of code as it is executed):
 
-        * ``general.remove_this_rundir``: (bool) Removes the entire run
+        * ``general.clean_this_rundir``: (bool) Removes the entire run
           directory.
 
-        * ``general.remove_old_rundirs_except``: (int) Removes the entire run
+        * ``general.clean_old_rundirs_except``: (int) Removes the entire run
           directory except for the last <x> runs
 
-        * ``general.remove_old_rundirs_keep_every``: (int) Removes the entire
+        * ``general.clean_old_rundirs_keep_every``: (int) Removes the entire
           run directory except every <x>th run
 
-        * ``general.remove_<filetype>_dir``: (bool) Erases the run directory
+        * ``general.clean_<filetype>_dir``: (bool) Erases the run directory
           for a specific filetype
 
-        * ``general.remove_size``: (int or float) Erases all files with size
-          greater than ``remove_size``, must be specified in bytes!
+        * ``general.clean_size``: (int or float) Erases all files with size
+          greater than ``clean_size``, must be specified in bytes!
         """
-        self._remove_run_determine_user_choice(config)
-        self._remove_this_rundir(config)
-        self._remove_old_rundirs_except(config)
-        self._remove_old_runs_filetypes(config)
-        self._remove_old_runs_size(config)
+        self._clean_run_determine_user_choice(config)
+        self._clean_this_rundir(config)
+        self._clean_old_rundirs_except(config)
+        self._clean_old_runs_filetypes(config)
+        self._clean_old_runs_size(config)
         return config
 
 
-    def _remove_run_determine_user_choice(self, config):
+    def _clean_run_determine_user_choice(self, config):
         """
         Determine user choice from a simple switch.
 
         The user sets::
 
         general:
-            remove_runs: <x>
+            clean_runs: <x>
 
         where ``x`` can be one of:
 
@@ -796,33 +796,33 @@ class SimulationSetup(object):
         * ``False`` Keeps run dir
         * ``int`` (must be >= 0) keep last ``x`` run dirs
         """
-        user_remove = config["general"].get("remove_runs")
+        user_clean = config["general"].get("clean_runs")
         # TODO(PG): It might be nice if these sorts of checks happened earlier
         # in the job, before it even gets to this function
-        if isinstance(user_remove, bool):
-            if "remove_this_run" not in config["general"]:
-                config["general"]["remove_this_run"] = user_remove
+        if isinstance(user_clean, bool):
+            if "clean_this_run" not in config["general"]:
+                config["general"]["clean_this_run"] = user_clean
             else:
                 print("------------------------------------------")
                 print("You have set both in your config:")
                 print()
                 print("general:")
-                print("    remove_this_run: ", config["general"]["remove_this_run"])
-                print("    remove_runs: ", user_remove)
+                print("    clean_this_run: ", config["general"]["clean_this_run"])
+                print("    clean_runs: ", user_clean)
                 print()
                 print("Please only use one of these!")
                 print("------------------------------------------")
                 sys.exit(1)
-        elif isinstance(user_remove, int):
-            if "remove_old_rundirs_except" not in config["general"]:
-                config["general"]["remove_old_rundirs_except"] = user_remove
+        elif isinstance(user_clean, int):
+            if "clean_old_rundirs_except" not in config["general"]:
+                config["general"]["clean_old_rundirs_except"] = user_clean
             else:
                 print("------------------------------------------")
                 print("You have set both in your config:")
                 print()
                 print("general:")
-                print("    remove_old_rundirs_except: ", config["general"]["remove_old_rundirs_except"])
-                print("    remove_runs: ", user_remove)
+                print("    clean_old_rundirs_except: ", config["general"]["clean_old_rundirs_except"])
+                print("    clean_runs: ", user_clean)
                 print()
                 print("Please only use one of these!")
                 print("------------------------------------------")
@@ -832,9 +832,9 @@ class SimulationSetup(object):
             print("Type Error!")
             print("You have set this in your config:")
             print("general:")
-            print("    remove_runs: ", user_remove)
+            print("    clean_runs: ", user_clean)
             print()
-            print("This is of type: ", type(user_remove))
+            print("This is of type: ", type(user_clean))
             print("However, only the following types are valid:")
             print("   * boolean")
             print("   * integer (greater or equal to 0!)")
@@ -843,18 +843,18 @@ class SimulationSetup(object):
             sys.exit(1)
 
 
-    def _remove_this_rundir(self, config):
-        if config['general'].get("remove_this_rundir", False):
+    def _clean_this_rundir(self, config):
+        if config['general'].get("clean_this_rundir", False):
             rm_r(config['general']['thisrun_dir'])
 
-    def _remove_old_rundirs_except(self, config):
+    def _clean_old_rundirs_except(self, config):
         all_run_folders_in_experiment = [folder for folder in os.listdir(config["general"]["experiment_dir"]) if folder.startswith("run_")]
         # Expand to full path names:
         all_run_folders_in_experiment = [pathlib.Path(config["general"]["experiment_dir"] + "/" + folder) for folder in all_run_folders_in_experiment]
         # Sort by creation time:
         all_run_folders_in_experiment.sort(key=os.path.getctime)
 
-        number_rundirs_keep_every = config["general"].get("remove_old_rundirs_keep_every")
+        number_rundirs_keep_every = config["general"].get("clean_old_rundirs_keep_every")
         runs_to_keep_via_keepevery = []
         if number_rundirs_keep_every:
             try:
@@ -865,14 +865,14 @@ class SimulationSetup(object):
                 print("-------------------------------------------------------------")
                 print()
                 print("general:")
-                print("   remove_old_rundirs_keep_every: <x>")
+                print("   clean_old_rundirs_keep_every: <x>")
                 print()
                 print("-------------------------------------------------------------")
                 print("<x> **MUST** be an integer greater or equal than 1!")
                 sys.exit(1)
             runs_to_keep_via_keepevery = all_run_folders_in_experiment[::number_rundirs_to_keep]
 
-        number_rundirs_to_keep = config["general"].get("remove_old_rundirs_except")
+        number_rundirs_to_keep = config["general"].get("clean_old_rundirs_except")
         runs_to_keep_via_end_select = []
         if number_rundirs_to_keep:
             try:
@@ -883,25 +883,25 @@ class SimulationSetup(object):
                 print("-------------------------------------------------------------")
                 print()
                 print("general:")
-                print("   remove_old_rundirs_except: <x>")
+                print("   clean_old_rundirs_except: <x>")
                 print()
                 print("-------------------------------------------------------------")
                 print("<x> **MUST** be an integer greater than 1!")
                 sys.exit(1)
             runs_to_keep_via_end_select = all_run_folders_in_experiment[:-number_rundirs_to_keep]
         runs_to_keep = set(runs_to_keep_via_keepevery + runs_to_keep_via_end_select)
-        runs_to_remove = set(all_run_folders_in_experiment) - runs_to_keep
-        for run in list(runs_to_remove):
+        runs_to_clean = set(all_run_folders_in_experiment) - runs_to_keep
+        for run in list(runs_to_clean):
             rm_r(run)
 
-    def _remove_old_runs_filetypes(self, config):
+    def _clean_old_runs_filetypes(self, config):
         all_filetypes = config['general']['all_filetypes']
         for filetype in all_filetypes:
-            if config['general'].get("remove_" + filetype + "_dir", False):
+            if config['general'].get("clean_" + filetype + "_dir", False):
                 rm_r(config['general']['thisrun_' + filetype + '_dir'])
 
-    def _remove_old_runs_size(self, config):
-        rmsize = config['general'].get("remove_size", False)
+    def _clean_old_runs_size(self, config):
+        rmsize = config['general'].get("clean_size", False)
         if rmsize:
             flist = []
             for root, _, files in os.walk(config['general']['thisrun_dir']):


### PR DESCRIPTION
# New Feature

This allows you to cleanup the `run_????` directories. The user has the following options available in their runscript:

```yaml
general:
    remove_this_rundir: True  # throws away the rundir that was just finished
    remove_old_rundirs_except: 5 # Throws away everything except the last 5 run dirs
   remove_old_rundirs_keep_every: 2 # throw away everything except every 2nd run dir
   remove_log_dir: True # Also valid for any other file type. Throws away the log dir of this run
   remove_size: 37890 # Throws away any file greater than x bytes (sorry, needs to be an int)
```


# TODO:
- [x] Actual implementation
- [x] Test drive it (@mandresm, can you see if this even works?)
- [x] User docs: should be in the handbook somewhere. There might be a way to directly include the doc-string from the main function as the user how-to 
- [x] Code docs (sort of started, but I could probably write more docstrings)

# Related Issues:
Will Close https://github.com/esm-tools/esm_tools/issues/96, https://github.com/esm-tools/esm_tools/issues/55