### PR TITLE
[FEATURE] no more file.log

### DIFF
--- a/esm_runscripts/cli.py
+++ b/esm_runscripts/cli.py
@@ -20,9 +20,6 @@ DEBUG_MODE = logger.level == logging.DEBUG
 FORMAT = (
     "[%(asctime)s,%(msecs)03d:%(filename)s:%(lineno)s - %(funcName)20s() ] %(message)s"
 )
-f_handler = logging.FileHandler("file.log")
-f_handler.setFormatter(FORMAT)
-logger.addHandler(f_handler)
 
 
 def parse_shargs():


### PR DESCRIPTION
Removes the annoying `file.log` that was generated whenever you used `esm_runscripts <config> <opts>`. It was always empty and never contained any info anyway...