### PR TITLE
Update runscripts in the experiment directory

### DIFF
--- a/esm_runscripts/cli.py
+++ b/esm_runscripts/cli.py
@@ -101,7 +101,7 @@ def parse_shargs():
     parser.add_argument(
         "-U",
         "--update",
-        help="[U]date the tools from the current version",
+        help="[U]pdate the runscript in the experiment folder and associated files",
         default=False,
         action="store_true",
     )

--- a/esm_runscripts/compute.py
+++ b/esm_runscripts/compute.py
@@ -325,8 +325,7 @@ class compute(jobclass):
             gconfig["profile"] = False
             compute.end_it_all(config, silent=True)
 
-    @classmethod
-    def update_runscript(cls, fromdir, scriptsdir, tfile, gconfig, file_type):
+    def update_runscript(fromdir, scriptsdir, tfile, gconfig, file_type):
         """
         Updates the script ``tfile`` in the directory ``scriptdir`` with the file in
         the directory ``fromdir`` if the update flag (``-U``) is used during the call of

--- a/esm_runscripts/compute.py
+++ b/esm_runscripts/compute.py
@@ -337,7 +337,7 @@ class compute(jobclass):
         Parameters
         ----------
         cls : obj
-            Compute objetc.
+            Compute object.
         fromdir : str
             Path of the source.
         scriptsdir : str
@@ -357,13 +357,13 @@ class compute(jobclass):
             ``esm_runscripts``, returns an error.
         """
 
-        # If the target path ``scriptsdir`` does not exist, then copy the file
+        # If the target file in ``scriptsdir`` does not exist, then copy the file
         # to the target.
         if not os.path.isfile(scriptsdir + "/" + tfile):
             oldscript = fromdir + "/" + tfile
             print(oldscript)
             shutil.copy2(oldscript, scriptsdir)
-        # If the target path exist compare the two scripts
+        # If the target path exists compare the two scripts
         else:
             import difflib
             import esm_parser
@@ -404,7 +404,7 @@ class compute(jobclass):
                         + (
                             f"If you want that {scriptsdir + '/' + tfile} is "
                             + "updated with the above changes, please use -U flag in the "
-                            + "esm_runscript call (WARNING: This will overwrite your "
+                            + "esm_runscripts call (WARNING: This will overwrite your "
                             + f"{file_type} in the experiment folder!)"
                         ),
                     )

--- a/esm_runscripts/compute.py
+++ b/esm_runscripts/compute.py
@@ -397,17 +397,39 @@ class compute(jobclass):
                 # If the --update flag is not called, exit with an error showing the
                 # user how to proceed
                 else:
-                    esm_parser.user_error(
+                    esm_parser.user_note(
                         f"Original {file_type} different from target",
                         differences
                         + "\n"
-                        + (
-                            f"If you want that {scriptsdir + '/' + tfile} is "
-                            + "updated with the above changes, please use -U flag in the "
-                            + "esm_runscripts call (WARNING: This will overwrite your "
-                            + f"{file_type} in the experiment folder!)"
-                        ),
+                        + "Note: You can choose to use -U flag in the esm_runscripts call "
+                        + "to automatically update the runscript (WARNING: This "
+                        + f"will overwrite your {file_type} in the experiment folder!)\n",
                     )
+                    correct_input = False
+                    while not correct_input:
+                        update_choice = input(
+                            f"Do you want that {scriptsdir + '/' + tfile} is "
+                            + "updated with the above changes? (y/n): "
+                        )
+                        if update_choice == "y":
+                            correct_input = True
+                            oldscript = fromdir + "/" + tfile
+                            print(oldscript)
+                            shutil.copy2(oldscript, scriptsdir)
+                            print(f"{scriptsdir + '/' + tfile} updated!")
+                        elif update_choice == "n":
+                            correct_input = True
+                            esm_parser.user_error(
+                                f"Original {file_type} different from target",
+                                differences
+                                + "\n"
+                                + "You can choose to -U flag in the esm_runscripts call "
+                                + "to update the runscript without asking (WARNING: This "
+                                + f"will overwrite your {file_type} in the experiment folder!)\n\n",
+                            )
+                        else:
+                            print(f"'{update_choice}' is not a valid answer.")
+
 
     @staticmethod
     def _copy_preliminary_files_from_experiment_to_thisrun(config):

--- a/esm_runscripts/compute.py
+++ b/esm_runscripts/compute.py
@@ -302,11 +302,15 @@ class compute(jobclass):
 
             # At this point, ``fromdir`` and ``scriptsdir`` are different. Update the
             # runscript if necessary
-            compute.update_runscript(fromdir, scriptsdir, gconfig["scriptname"], gconfig, "runscript")
+            compute.update_runscript(
+                fromdir, scriptsdir, gconfig["scriptname"], gconfig, "runscript"
+            )
 
             # Update the ``additional_files`` if necessary
             for tfile in gconfig["additional_files"]:
-                compute.update_runscript(fromdir, scriptsdir, tfile, gconfig, "additional file")
+                compute.update_runscript(
+                    fromdir, scriptsdir, tfile, gconfig, "additional file"
+                )
 
             restart_command = (
                 "cd "
@@ -363,15 +367,17 @@ class compute(jobclass):
         else:
             import difflib
             import esm_parser
+
             script_o = open(fromdir + "/" + tfile).readlines()
             script_t = open(scriptsdir + "/" + tfile).readlines()
 
             diffobj = difflib.SequenceMatcher(a=script_t, b=script_o)
             # If the files are different
-            if not diffobj.ratio()==1:
+            if not diffobj.ratio() == 1:
                 # Find differences
-                differences = (f"{fromdir + '/' + tfile} differs from " +
-                    f"{scriptsdir + '/' + tfile}:\n"
+                differences = (
+                    f"{fromdir + '/' + tfile} differs from "
+                    + f"{scriptsdir + '/' + tfile}:\n"
                 )
                 for line in difflib.unified_diff(script_t, script_o):
                     differences += line
@@ -379,9 +385,11 @@ class compute(jobclass):
                 # If the --update flag is used, notify that the target script will
                 # be updated and do update it
                 if gconfig["update"]:
-                    esm_parser.user_note(f"Original {file_type} different from target",
-                        differences + "\n" +
-                        f"{scriptsdir + '/' + tfile} will be updated!"
+                    esm_parser.user_note(
+                        f"Original {file_type} different from target",
+                        differences
+                        + "\n"
+                        + f"{scriptsdir + '/' + tfile} will be updated!",
                     )
                     oldscript = fromdir + "/" + tfile
                     print(oldscript)
@@ -389,13 +397,16 @@ class compute(jobclass):
                 # If the --update flag is not called, exit with an error showing the
                 # user how to proceed
                 else:
-                    esm_parser.user_error(f"Original {file_type} different from target",
-                        differences + "\n" +
-                        (f"If you want that {scriptsdir + '/' + tfile} is " +
-                        "updated with the above changes, please use -U flag in the " +
-                        "esm_runscript call (WARNING: This will overwrite your " +
-                        f"{file_type} in the experiment folder!)"
-                        )
+                    esm_parser.user_error(
+                        f"Original {file_type} different from target",
+                        differences
+                        + "\n"
+                        + (
+                            f"If you want that {scriptsdir + '/' + tfile} is "
+                            + "updated with the above changes, please use -U flag in the "
+                            + "esm_runscript call (WARNING: This will overwrite your "
+                            + f"{file_type} in the experiment folder!)"
+                        ),
                     )
 
     @staticmethod


### PR DESCRIPTION
This hotfix solves issue esm-tools/esm_tools#175 in the following way:
- If running `esm_runscript` without `-U`, and `${base_dir}/${experiment_id}/scripts/<runscript_invoked_by_the_user>.yaml`  exists then reports an **error** saying that the runscript already exists and that the user needs to use the `-U` flag which means that the runscript will be overwritten. 
- This error only happens if the runscripts are not identical. If they are not identical the error returns the difference in a similar format as diff .
- If running `esm_runscript` with `-U` , and `${base_dir}/${experiment_id}/scripts/<runscript_invoked_by_the_user>.yaml` exists, overwrites it. Differences are also reported back to the user.