### PR TITLE
removed export_mode from oasis.py. Instead set by full_config[self.na…

### DIFF
--- a/esm_runscripts/esm_coupler.py
+++ b/esm_runscripts/esm_coupler.py
@@ -230,8 +230,12 @@ class esm_coupler:
                         if "coupling_methods" in full_config[self.name]:
                             if interpolation in full_config[self.name]["coupling_methods"]:
                                 transf_info=full_config[self.name]["coupling_methods"][interpolation]
-
-                        self.coupler.add_coupling(lefts, lgrid_info, rights, rgrid_info, direction_info, transf_info, restart_file, full_config[self.name]["coupling_time_step"], full_config[self.name]["lresume"])
+                        if "export_mode" in full_config[self.name]:
+                            export_mode = full_config[self.name]["export_mode"]
+                        else:
+                            export_mode = "EXPORTED" 
+                        print("DEBUG: EXPORT_MODE: ",export_mode)
+                        self.coupler.add_coupling(lefts, lgrid_info, rights, rgrid_info, direction_info, transf_info, restart_file, full_config[self.name]["coupling_time_step"], full_config[self.name]["lresume"], export_mode=export_mode)
 
                         
 

--- a/esm_runscripts/oasis.py
+++ b/esm_runscripts/oasis.py
@@ -37,7 +37,7 @@ class oasis:
         self.next_coupling=1
         self.name = "oasis3mct"
 
-    def add_coupling(self, lefts, lgrid, rights, rgrid, direction, transformation, restart_file, time_step, lresume):
+    def add_coupling(self, lefts, lgrid, rights, rgrid, direction, transformation, restart_file, time_step, lresume, export_mode="EXPORTED"):
         import sys
         self.namcouple += ["#"]
 
@@ -56,14 +56,12 @@ class oasis:
         for righty in rights:
             right += sep + righty
             sep = ":" 
-
+         
         if lresume == False:
             lag = str(0)
-            export_mode = "EXPOUT"
         else:
             lag = direction.get("lag", "0")
-            export_mode = "EXPORTED"
-         
+        
         # if a transformation method for CONSERV (e.g. GLOBAL) is set below, 
         # increase seq (=number of lines describing the transformation) by 1
         seq = int(direction.get("seq", "2"))


### PR DESCRIPTION
I realised there's no way to control "export_mode" for OASIS in ESM-Tools. 
I would like the user to be able to set "EXPORTED" or "EXPOUT" (write coupling fields to disk) in oasis3mct.yaml

The old behaviour was to use EXPOUT for initial runs and EXPORTED when resume=True. 
I've changed so that the user sets export_mode in oasis3mct.yaml, similar to how coupling_frequency is set. 
If nothing is set, the model defaults to EXPORTED. 

Does this sound like a a good addition to ESM-Runscripts? 

Cheers
Joakim 