### PR TITLE
Exception to add_<env_vars> added to the environment case checker

### DIFF
--- a/esm_runscripts/prepare.py
+++ b/esm_runscripts/prepare.py
@@ -163,7 +163,7 @@ def model_env_into_computer(config):
         # need of the solving of later ``choose_`` blocks.
         for key, value in modelconfig["environment_changes"].items():
             if (
-                key not in ["export_vars", "module_actions"]
+                key not in ["export_vars", "module_actions", "add_export_vars", "add_module_actions"]
                 and "computer" in config
                 and not overwrite
                 #and run_or_compile=="runtime"


### PR DESCRIPTION
Exceptions for export_vars and module actions were already present for the new environment case checker (#48), but an error could potentially occur when there was a add_export_vars or add_module_actions in the environment dictionaries of a component. add_export_vars and add_module_actions are added here as exceptions for the environment case checker.

Solves esm-tools/esm_tools#248