### PR TITLE
Hotfix/trace log into log dir

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.0.5"
+__version__ = "5.0.6"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/cli.py
+++ b/esm_runscripts/cli.py
@@ -10,6 +10,7 @@ import os
 import sys
 
 from .sim_objects import *
+from .helpers import SmartSink
 from loguru import logger
 from esm_motd import check_all_esm_packages
 
@@ -173,8 +174,13 @@ def main():
     command_line_config["original_command"] = original_command.strip()
     command_line_config["started_from"] = os.getcwd()
 
+    # Define a sink object to store the logs. Path of the logs can be later specified
+    # by using <sink_obj>.def_path(<path>)
+    trace_sink = SmartSink()
+    logger.trace_sink = trace_sink
+
     logger.remove()
-    logger.add("verbose.log", level="TRACE")
+    logger.add(trace_sink.sink, level="TRACE")
 
     logger.add(sys.stdout, level="INFO", format="{message}")
     if verbose:

--- a/esm_runscripts/compute.py
+++ b/esm_runscripts/compute.py
@@ -13,6 +13,7 @@ from .batch_system import batch_system
 from .filelists import copy_files, log_used_files
 from .helpers import end_it_all, evaluate, write_to_log
 from .namelists import Namelist
+from loguru import logger
 
 #####################################################################
 #                                   compute jobs                    #
@@ -283,6 +284,18 @@ def initialize_experiment_logfile(config):
             "- submitted",
         ],
     )
+
+    # Write trace-log file now that we know where to do that
+    if "trace_sink" in dir(logger):
+        logger.trace_sink.def_path(
+            config["general"]["experiment_dir"] +
+            "/log/" +
+            config["general"]["expid"] +
+            "_esm_runscripts_" +
+            config["general"]["run_datestamp"] +
+            ".log"
+        )
+
     return config
 
 

--- a/esm_runscripts/helpers.py
+++ b/esm_runscripts/helpers.py
@@ -137,3 +137,71 @@ def assemble_log_message(
     # TODO: Do we want to be able to specify a timestamp seperator as well?
     line = timestampStr + " : " + message_sep.join(message)
     return line
+
+
+############################## SINK CLASS FOR LOGURU.LOGGER ###########################
+
+class SmartSink():
+    '''
+    A class for smart sinks that allow for logging (using ``logger`` from loguru), even
+    if the file path of the log file is not yet defined. The actual sink is not the
+    instanced object itself, but the method ``sink`` of the instance. The log record is
+    saved in ``self.log_record`` and the log file is written using the path specified
+    in ``self.path``. If the path is not specified, the log is stored only in the
+    ``self.log_record``. When the path is finally specified, ``self.log_record`` is
+    dumped into the log file and from that moment, any time ``logger`` logs something it
+    will also be written into the file. To specify the path the method ``def_path``
+    needs to be used.
+    '''
+
+    def __init__(self):
+        # Initialise instance variables
+        self.log_record = []
+        self.path = None
+
+    def sink(self, message):
+        '''
+        The actual sink for loguru's ``logger``. Once you define a logger level a sink
+        needs to be provided. Standard sinks include file paths, methods, etc.
+        Providing this method as a sink (``logger.add(<name_of_the_instance>.sink,
+        level="<your_level>", ...)``) enables the functionality of the SmartSink object.
+
+        Parameters
+        ----------
+        message : str
+            String containing the logging message.
+        '''
+        if self.path:
+            self.write_log(message, "a")
+        self.log_record.append(message)
+
+    def write_log(self, message, wmode):
+        '''
+        Method to write the logs into the disk.
+
+        Parameters
+        ----------
+        message : str, list
+            String containing the logging message or list containing more than one
+            logging message, to be written in the file.
+        wmode : str
+            Writing mode to choose among ``"w"`` or ``"a"``.
+        '''
+        if isinstance(message, str):
+            message = [message]
+        with open(self.path, wmode) as log:
+            for line in message:
+                log.write(line)
+
+    def def_path(self, path):
+        '''
+        Method to define the path of the file. Once the path is defined, the log record
+        is written into the file.
+
+        Parameters
+        ----------
+        path : str
+            Path of the logging file.
+        '''
+        self.path = path
+        self.write_log(self.log_record, "w")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.5
+current_version = 5.0.6
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="5.0.5",
+    version="5.0.6",
     zip_safe=False,
 )


### PR DESCRIPTION
Solves esm-tools/esm_tools#242

Adds a SmartSink class to the helpers to be able to manage the `logger` more dynamically:
- A `sink` method of this class takes care of recording the logs.
- A `def_path` method of the class can be used to define the path later, where the log is to be dumped.