### PR TITLE
fix the ulimit -s

### DIFF
--- a/esm_runscripts/batch_system.py
+++ b/esm_runscripts/batch_system.py
@@ -124,7 +124,7 @@ class batch_system:
         extras = []
         if config["general"].get("unlimited_stack_size", True):
             extras.append("# Set stack size to unlimited")
-            extras.append("ulimit -s")
+            extras.append("ulimit -s unlimited")
         if config['general'].get('use_venv', False):
             extras.append("# Start everything in a venv")
             extras.append("source "+config["general"]["experiment_dir"]+"/.venv_esmtools/bin/activate")


### PR DESCRIPTION
`ulimit -s` is a get command it does not set any value. As you can see in the log file it prints the stack size (usually `unlimited`).

Instead, it should be `ulimit -s unlimited` which actually sets the stack size. 