### PR TITLE
create parent dirs

### DIFF
--- a/esm_runscripts/filelists.py
+++ b/esm_runscripts/filelists.py
@@ -583,7 +583,10 @@ def copy_files(config, filetypes, source, target):
                     if not os.path.isdir(file_source):
                         try:
                             if not os.path.isdir(dest_dir):
-                                os.mkdir(dest_dir)
+                                # MA: ``os.makedirs`` creates the specified directory
+                                # and the parent directories if the last don't exist
+                                # (same as with ``mkdir -p <directory>>``)
+                                os.makedirs(dest_dir)
                             if not os.path.isfile(file_source):
                                 print(f"File not found: {file_source}...")
                                 missing_files.update({file_target: file_source})


### PR DESCRIPTION
Copy_files method is now capable of creating parent directories of a path to be copied.

The problem before this change can be illustrated by the following example on `oifs.yaml`:
```
input_in_work:
        [ ... ]
        tl_data: ${res_number_tl}/*
        o3_data: ${res_number_tl}/o3chem_l${nlev}/*
```

What we want here is that `o3_data` contents of the source are copied into the `<exp_path>/run_<DATE>/input/oifs/${res_number_tl}/o3chem_l${nlev}/`. However, `<exp_path>/run_<DATE>/input/oifs/${res_number_tl}` does not exist on the first place so `esm_runscripts` was failing to create `<exp_path>/run_<DATE>/input/oifs/${res_number_tl}/o3chem_l${nlev}/` when using `os.mkdir`. 

That was worked around in the `oifs.yaml` by copying first the `<exp_path>/run_<DATE>/input/oifs/${res_number_tl}`, however, there might be cases in which we would want to exclusively copy the content of a directory and still preserv its parents. To solve that I changed the `os.mkdir` command for `os.makedirs` which does the same as `mkdir -p` in bash.