### PR TITLE
Coupling fields, different models

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.0.11"
+__version__ = "5.0.12"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/oasis.py
+++ b/esm_runscripts/oasis.py
@@ -357,8 +357,8 @@ class oasis:
                 print (filelist)
         # MA: -O flag added to overwrite oasis restart files in case oasis creats them
         # before (i.e. when using LOCTRANS)
-        if os.path.isfile(filelist):
-            print(f"{filelist} already exits, overwriting")
+        if os.path.isfile(restart_file) and config["general"]["verbose"]:
+            print(f"{restart_file} already exits, overwriting")
         print("cdo -O merge " + filelist + " " + restart_file )#+ enddate)
         os.system("cdo -O merge " + filelist + " " + restart_file )# + enddate)
         rmlist = glob.glob("notimestep*")

--- a/esm_runscripts/oasis.py
+++ b/esm_runscripts/oasis.py
@@ -324,7 +324,7 @@ class oasis:
 
 
 
-    def prepare_restarts(self, restart_file, all_fields, model, config):
+    def prepare_restarts(self, restart_file, all_fields, models, config):
         enddate = "_" + config["general"]["end_date"].format(
                 form=9, givenph=False, givenpm=False, givenps=False
             )
@@ -333,12 +333,14 @@ class oasis:
         import os
         import subprocess
         print("Preparing oasis restart files from initial run...")
-        exe = config[model]["executable"]
-        print (restart_file, all_fields, model, exe)
+        # Assign an exe per model
+        exes = [config[model]["executable"] for model in models]
+        print (restart_file, all_fields, models, exes)
         cwd = os.getcwd()
         os.chdir(config["general"]["thisrun_work_dir"])
         filelist = ""
-        for field in all_fields:
+        # Loop through the fields and their corresponding models and exes
+        for field, model, exe in zip(all_fields, models, exes):
             print (field + "-" + model)
             thesefiles = glob.glob(field + "_" + exe + "_*.nc")
             print (thesefiles)
@@ -353,8 +355,10 @@ class oasis:
                 os.system("ncwa -O -a time onlyonetimestep.nc notimestep_" + field + ".nc")
                 filelist += "notimestep_" + field + ".nc "
                 print (filelist)
-        print("cdo merge " + filelist + " " + restart_file )#+ enddate)
-        os.system("cdo merge " + filelist + " " + restart_file )# + enddate)
+        # MA: -O flag added to overwrite oasis restart files in case oasis creats them
+        # before (i.e. when using LOCTRANS)
+        print("cdo -O merge " + filelist + " " + restart_file )#+ enddate)
+        os.system("cdo -O merge " + filelist + " " + restart_file )# + enddate)
         rmlist = glob.glob("notimestep*")
         rmlist.append("onlyonetimestep.nc")
         for rmfile in rmlist:

--- a/esm_runscripts/oasis.py
+++ b/esm_runscripts/oasis.py
@@ -357,6 +357,8 @@ class oasis:
                 print (filelist)
         # MA: -O flag added to overwrite oasis restart files in case oasis creats them
         # before (i.e. when using LOCTRANS)
+        if os.path.isfile(filelist):
+            print(f"{filelist} already exits, overwriting")
         print("cdo -O merge " + filelist + " " + restart_file )#+ enddate)
         os.system("cdo -O merge " + filelist + " " + restart_file )# + enddate)
         rmlist = glob.glob("notimestep*")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.11
+current_version = 5.0.12
 commit = True
 tag = True
 
@@ -20,4 +20,3 @@ select = C,E,F,W,B,B950
 ignore = E203, E501, W503
 
 [aliases]
-

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="5.0.11",
+    version="5.0.12",
     zip_safe=False,
 )


### PR DESCRIPTION
This solves issue #66.

There were 2 problems in creating the first restart file for `oasis3mct` (when `oasis3mct.lresume: 0`):

1. As @JanStreffing pointed out, the use of `LOCTRANS` results in `oasis3mct` creating a coupling restart file with the same name that the built up restart file will take during the `prepare_restarts` method in `oasis.py`. This leads to `cdo merge` aborting the merge. The solution was to add the flag `-O` to the merge command, as pointed out by @pgierz .

2. In `AWICM3`, the restart file `rstas.nc` contains fields from more than one model (the right side contains fields from `oifs` and `rnfmap`):
```
        coupling_target_fields:
                rstas.nc:
                        - 'heat_oce:heat_swo <--bicubic_glb-- A_Qns_oce:A_Qs_all'
                        - 'prec_oce:snow_oce:evap_oce:subl_oce <--bicubic_glb-- A_Precip_liquid:A_Precip_solid:A_Evap:A_Subl'
                        - 'heat_ico <--bicubic_gss-- A_Q_ice'
                        - 'taux_oce:tauy_oce:taux_ico:tauy_ico <--bicubic-- A_TauX_oce:A_TauY_oce:A_TauX_ice:A_TauY_ice'
                        - 'R_Runoff_atm <--bicubic-- A_Runoff'
                        - 'hydr_oce <--gauswgt_c-- R_Runoff_oce'

```
`prepare_restarts` in `coupler.py` was not prepared to support more than one model per file. This was solved also in this hotfix.