### PR TITLE
subdirs on targets

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.0.12"
+__version__ = "5.0.13"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/filelists.py
+++ b/esm_runscripts/filelists.py
@@ -257,6 +257,10 @@ def target_subfolders(config):
                             config[model][filetype + "_targets"][
                                 descr
                             ] = filename.replace("*", source_filename)
+                        elif "/" in filename:
+                            config[model][filetype + "_targets"][
+                                descr
+                            ] = "/".join(filename.split("/")[:-1]) + "/" + source_filename
                         else:
                             config[model][filetype + "_targets"][
                                 descr

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.12
+current_version = 5.0.13
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="5.0.12",
+    version="5.0.13",
     zip_safe=False,
 )


### PR DESCRIPTION
It was not possible for `esm_runscripts` to copy files into a subfolder of the main experiment folders when they were coming directly from the source, and not from the respective subfolder in the source (i.e. copy a file from `work exp_id/run_DATE/work/a_file` into a subfolder in outdata `exp_id/outdata/model/subfolder/a_file`). This hotfix solves the issue.