### PR TITLE
Hotfix/subdirs on targets followup

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.0.13"
+__version__ = "5.0.14"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/filelists.py
+++ b/esm_runscripts/filelists.py
@@ -260,11 +260,11 @@ def target_subfolders(config):
                         elif "/" in filename:
                             config[model][filetype + "_targets"][
                                 descr
-                            ] = "/".join(filename.split("/")[:-1]) + "/" + source_filename
+                            ] = "/".join(filename.split("/")[:-1]) + "/" + source_filename.split("/")[-1]
                         else:
                             config[model][filetype + "_targets"][
                                 descr
-                            ] = source_filename
+                            ] = source_filename.split("/")[-1]
                     elif filename.endswith("/"):
                         source_filename = os.path.basename(
                             config[model][filetype + "_sources"][descr]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.13
+current_version = 5.0.14
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="5.0.13",
+    version="5.0.14",
     zip_safe=False,
 )


### PR DESCRIPTION
Allows copying from a subfolder in the `source` into the `target` folder, no subfolder, so the inverse process of #69 (i.e. from `restarts/oifs/<data_stamped_subfolder>` to `run_<date>/work`).