### PR TITLE
Reusable_filetypes in config files

### DIFF
--- a/esm_runscripts/filelists.py
+++ b/esm_runscripts/filelists.py
@@ -154,7 +154,7 @@ def reuse_sources(config):
                     config[model][filetype + "_sources"][categ] = (
                         config[model]["experiment_" + filetype + "_dir"]
                         + "/"
-                        + config[model][filetype + "_targets"][categ].split("/")[-1]
+                        + config[model][filetype + "_targets"][categ]
                     )
     return config
 

--- a/esm_runscripts/prepare.py
+++ b/esm_runscripts/prepare.py
@@ -442,7 +442,7 @@ def _add_all_folders(config):
         "config",
         "restart_in",
     ]
-    config["general"]["reusable_filetypes"] = ["bin", "src"]
+    config["general"]["reusable_filetypes"] = config["general"].get("reusable_filetypes", ["bin", "src"])
 
     config["general"]["thisrun_dir"] = (
         config["general"]["experiment_dir"]


### PR DESCRIPTION
Allows to define the `reusable_filetypes` variable inside the general section of a simulation. By default the only reusable files are `bin` and `src`. With this change it is possible to also reuse, for example, `input`. This means that the simulation will copy the input once into the experiment folder, and will use copies or links of this input in the experiment folder (`<exp_path>/input`) for the following legs/runs.

Additionally, another fix is included: Reused subfolders can be now copied correctly into the work directory (before it was making a mess)