### PR TITLE
fix/venv_with_editable_branched_packages

### DIFF
--- a/esm_runscripts/virtual_env_builder.py
+++ b/esm_runscripts/virtual_env_builder.py
@@ -115,9 +115,9 @@ def _install_tools_general(venv_context, config, deps=True):
     '''
     # Setup the --no-deps flag if necessary
     if not deps:
-        no_deps_flag = "--no-deps"
+        no_deps_flag = ["--no-deps"]
     else:
-        no_deps_flag = ""
+        no_deps_flag = []
     # Loop through the esm_tools packages to be installed
     for tool in esm_tools_modules:
         # Module info (url, editable install, branch...)
@@ -138,7 +138,7 @@ def _install_tools_general(venv_context, config, deps=True):
             # Clone from git
             subprocess.check_call(f"git clone --quiet {branch_command} {url} {src_dir}", shell=True)
             # Carry out the editable installation (with or without dependencies)
-            _run_bin_in_venv(venv_context, ["pip", "install", "-q", f"--find-links={os.environ.get('HOME')}/.cache/pip/wheels", "-e", src_dir, no_deps_flag])
+            _run_bin_in_venv(venv_context, ["pip", "install", "-q", f"--find-links={os.environ.get('HOME')}/.cache/pip/wheels", "-e", src_dir] + no_deps_flag)
             _run_bin_in_venv(venv_context, ["pip", "wheel", "-q", f"--wheel-dir={os.environ.get('HOME')}/.cache/pip/wheels", src_dir])
         # If the package is not editable then do a standard installation.
         # Note: this step only runs with the `--no-deps` flag if the user has specified
@@ -150,7 +150,7 @@ def _install_tools_general(venv_context, config, deps=True):
             if user_wants_branch:
                 url += f"@{user_wants_branch}"
             # NOTE(PG): We need the -U flag to ensure the branch is actually installed.
-            _run_bin_in_venv(venv_context, ["pip", "install", '-q', f"--find-links={os.environ.get('HOME')}/.cache/pip/wheels", "-U", url, no_deps_flag])
+            _run_bin_in_venv(venv_context, ["pip", "install", '-q', f"--find-links={os.environ.get('HOME')}/.cache/pip/wheels", "-U", url] + no_deps_flag)
             _run_bin_in_venv(venv_context, ["pip", "wheel", '-q', f"--wheel-dir={os.environ.get('HOME')}/.cache/pip/wheels", url])
 
 def _install_required_plugins(venv_context, config):

--- a/esm_runscripts/virtual_env_builder.py
+++ b/esm_runscripts/virtual_env_builder.py
@@ -59,30 +59,99 @@ def _source_and_run_bin_in_venv(venv_context, command, shell):
     return subprocess.check_call(command, shell=shell)
 
 def _install_tools(venv_context, config):
-    #_run_bin_in_venv(venv_context, ['pip', 'install', 'git+https://github.com/esm-tools/esm_tools'])
+    """
+    Installs the ESM-Tools packages for a virtual environment, taking into account
+    the user's specifications for editable packages and desired branches.
+
+    To control which packages are installed in editable mode the user can add the
+    following to their runscript:
+
+    .. code-block:: yaml
+
+       general:
+           install_<esm_package>_editable: True/False
+
+    To control which package branch is installed (compatible with editable mode and
+    non-editable mode) the user can add the following to their runscript:
+
+    .. code-block:: yaml
+
+       general:
+           install_<esm_package>_branch: <branch_name>
+
+    Parameters
+    ----------
+    venv_context : type
+        Some description
+    config : dict
+        Configuration dictionary for this run
+    """
+
+    # First installation of all packages, with the desired mode (editable/non-editable),
+    # and branches, together with all their dependencies
+    _install_tools_general(venv_context, config)
+    # Some packages, such as `esm_tools` have other packages as dependencies (i.e.
+    # `esm_parser`). In the previous step, if a package is installed for which a
+    # dependency is editable and/or branched, this dependency gets back to non-editable
+    # realese-branch. The following line resinstalls all the editable/branched packages
+    # again, this time without dependencies.
+    _install_tools_general(venv_context, config, deps=False)
+
+def _install_tools_general(venv_context, config, deps=True):
+    '''
+    Actual installer of ESM-Tools packages for virtual environments. Used by
+    `_install_tools` method to correctly install packages with the user's requested
+    options for each package (editable/non-editable and branch). See `_install_tools`
+    documentation for more information.
+
+    Parameters
+    ----------
+    venv_context : type
+        Some description
+    config : dict
+        Configuration dictionary for this run
+    deps : bool
+        Boolean indicating whether dependencies should be installed or not
+    '''
+    # Setup the --no-deps flag if necessary
+    if not deps:
+        no_deps_flag = "--no-deps"
+    else:
+        no_deps_flag = ""
+    # Loop through the esm_tools packages to be installed
     for tool in esm_tools_modules:
+        # Module info (url, editable install, branch...)
         url = f"https://github.com/esm-tools/{tool}"
         user_wants_editable = config["general"].get(f"install_{tool}_editable", False)
         user_wants_branch = config["general"].get(f"install_{tool}_branch")
+        # If the package is editable install it in <EXP_PATH>/src/esm-tools/
         if user_wants_editable:
             # Make sure the directory exists:
             src_dir = pathlib.Path(config['general']['experiment_dir'] + f"/src/esm-tools/{tool}")
-            src_dir.mkdir(parents=True, exist_ok=True)
+            if not src_dir.exists():
+                src_dir.mkdir(parents=True, exist_ok=True)
+            # Select branch if necessary
             if user_wants_branch:
                 branch_command = f" -b {user_wants_branch} "
             else:
                 branch_command = ""
+            # Clone from git
             subprocess.check_call(f"git clone --quiet {branch_command} {url} {src_dir}", shell=True)
-            _run_bin_in_venv(venv_context, ["pip", "install", "-q", f"--find-links={os.environ.get('HOME')}/.cache/pip/wheels", "-e", src_dir])
+            # Carry out the editable installation (with or without dependencies)
+            _run_bin_in_venv(venv_context, ["pip", "install", "-q", f"--find-links={os.environ.get('HOME')}/.cache/pip/wheels", "-e", src_dir, no_deps_flag])
             _run_bin_in_venv(venv_context, ["pip", "wheel", "-q", f"--wheel-dir={os.environ.get('HOME')}/.cache/pip/wheels", src_dir])
-        else:
+        # If the package is not editable then do a standard installation.
+        # Note: this step only runs with the `--no-deps` flag if the user has specified
+        # a branch, as this flags means also that is the second time passing through
+        # here, and we don't want to waste time on installing everything a second time
+        # if not necessary.
+        elif deps or (not deps and user_wants_branch):
             url = f"git+{url}"
             if user_wants_branch:
                 url += f"@{user_wants_branch}"
             # NOTE(PG): We need the -U flag to ensure the branch is actually installed.
-            _run_bin_in_venv(venv_context, ["pip", "install", '-q', f"--find-links={os.environ.get('HOME')}/.cache/pip/wheels", "-U", url])
+            _run_bin_in_venv(venv_context, ["pip", "install", '-q', f"--find-links={os.environ.get('HOME')}/.cache/pip/wheels", "-U", url, no_deps_flag])
             _run_bin_in_venv(venv_context, ["pip", "wheel", '-q', f"--wheel-dir={os.environ.get('HOME')}/.cache/pip/wheels", url])
-
 
 def _install_required_plugins(venv_context, config):
     required_plugins = []

--- a/esm_runscripts/virtual_env_builder.py
+++ b/esm_runscripts/virtual_env_builder.py
@@ -136,7 +136,8 @@ def _install_tools_general(venv_context, config, deps=True):
             else:
                 branch_command = ""
             # Clone from git
-            subprocess.check_call(f"git clone --quiet {branch_command} {url} {src_dir}", shell=True)
+            if deps:
+                subprocess.check_call(f"git clone --quiet {branch_command} {url} {src_dir}", shell=True)
             # Carry out the editable installation (with or without dependencies)
             _run_bin_in_venv(venv_context, ["pip", "install", "-q", f"--find-links={os.environ.get('HOME')}/.cache/pip/wheels", "-e", src_dir] + no_deps_flag)
             _run_bin_in_venv(venv_context, ["pip", "wheel", "-q", f"--wheel-dir={os.environ.get('HOME')}/.cache/pip/wheels", src_dir])


### PR DESCRIPTION
This fix solves the following problem:

I have 4 packages to be installed in editable mode within a `venv` run: esm_parser , esm_rcfile, esm_runscripts and esm_tools. I've been monitoring the files in <EXP_PATH>/.venv_esmtools/lib/python3.7/site-packages/  and I observed the following:
1. the first to be installed is esm_parser and creates its corresponding esm-parser.egg-link
2. then it comes esm_rcfile  and it creates its esm-rcfile.egg-link 
3. during the installation of esm_runscripts an esm-runscripts.egg-link is created but the previous are destroyed and substituted by their non-editable source-code versions (in release)
finally the installation of esm_tools ends up destroying all editable installations. 

The same happens if I do pip install -e . for the above packages in that order.

This is happening because of the `install_requires` in the `setup.py` of `esm_tools` and `esm_runscripts` contain dependencies to `esm_parser` and `esm_rcfile`. **When the dependencies are installed the editable mode of those and/or the selected branch are ruled out.**

**TODO:**

- [x] Finish testing