### PR TITLE
Feature/esm tools dir class

### DIFF
--- a/esm_runscripts/compute.py
+++ b/esm_runscripts/compute.py
@@ -485,21 +485,14 @@ def copy_tools_to_thisrun(config):
     # In case there is no esm_tools or namelists in the experiment folder,
     # copy from the default esm_tools path
     if not os.path.isdir(tools_dir):
-        if config['general'].get("use_venv") or esm_rcfile.FUNCTION_PATH.startswith("NONE_YET"):
-            if config["general"]["verbose"]:
-                print("Copying standard yamls from: package interal configs")
-            esm_tools.copy_config_folder(tools_dir)
-        else:
-            if config["general"]["verbose"]:
-                print("Copying from: ", esm_rcfile.FUNCTION_PATH)
-            shutil.copytree(esm_rcfile.FUNCTION_PATH, tools_dir)
+        print("Copying standard yamls from: ", esm_rcfile.EsmToolsDir("FUNCTION_PATH"))
+        esm_tools.copy_config_folder(tools_dir)
     if not os.path.isdir(namelists_dir):
-        if esm_rcfile.get_rc_entry("NAMELIST_PATH", "NONE_YET").startswith("NONE_YET"):
-            if config["general"]["verbose"]:
-                print("Copying standard namelists from: package internal namelists")
-            esm_tools.copy_namelist_folder(namelists_dir)
-        else:
-            shutil.copytree(esm_rcfile.get_rc_entry("NAMELIST_PATH"), namelists_dir)
+        print(
+            "Copying standard namelists from: ",
+            esm_rcfile.EsmToolsDir("NAMELIST_PATH"),
+        )
+        esm_tools.copy_namelist_folder(namelists_dir)
 
     # If ``fromdir`` and ``scriptsdir`` are the same, this is already a computing
     # simulation which means we want to use the script in the experiment folder,

--- a/esm_runscripts/filelists.py
+++ b/esm_runscripts/filelists.py
@@ -566,22 +566,6 @@ def copy_files(config, filetypes, source, target):
                 targetblock = config[model][filetype + "_" + text_target]
                 for categ in sourceblock:
                     file_source = os.path.normpath(sourceblock[categ])
-                    # NOTE(PG): This is a really, really, REALLY bad hack and it
-                    # makes me physically ill to look at:
-                    # NOTE(MA): The previous implementation was not able to include
-                    # namelists that have no ``namelist`` in their name. This is a more
-                    # general implementation but it enforces the use of the
-                    # ``namelists`` list to be defined for each model with namelists.
-                    namelist_candidates = (
-                        [item for item in config[model].get("namelists", [])]
-                        + ["namelist"]
-                    )
-                    isnamelist = any(map(file_source.__contains__, namelist_candidates))
-                    if source == "init":
-                        if isnamelist and file_source.startswith("NONE_YET"):
-                            file_source = esm_tools.get_namelist_filepath(
-                                file_source.replace("NONE_YET/", "")
-                            )
                     file_target = os.path.normpath(targetblock[categ])
                     if config["general"]["verbose"]:
                         print(f"source: {file_source}")

--- a/esm_runscripts/helpers.py
+++ b/esm_runscripts/helpers.py
@@ -28,32 +28,12 @@ def evaluate(config, job_type, recipe_name):
             % setup_name
         )
         sys.exit(1)
-    if config["general"].get("use_venv"):
-        recipe = esm_tools.get_config_filepath("esm_software/esm_runscripts/esm_runscripts.yaml")
-        need_to_parse_recipe = True
-        plugins_bare = esm_tools.get_config_filepath(
-            "esm_software/esm_runscripts/esm_plugins.yaml"
-        )
-        need_to_parse_plugins = True
-    elif esm_rcfile.FUNCTION_PATH.startswith("NONE_YET"):
-        recipe = esm_tools.get_config_filepath(
-            "esm_software/esm_runscripts/esm_runscripts.yaml"
-        )
-        need_to_parse_recipe = True
-        plugins_bare = esm_tools.get_config_filepath(
-            "esm_software/esm_runscripts/esm_plugins.yaml"
-        )
-        need_to_parse_plugins = True
-    else:
-        recipe = (
-            esm_rcfile.FUNCTION_PATH
-            + "/esm_software/esm_runscripts/esm_runscripts.yaml"
-        )
-        need_to_parse_recipe = True
-        plugins_bare = (
-            esm_rcfile.FUNCTION_PATH + "/esm_software/esm_runscripts/esm_plugins.yaml"
-        )
-        need_to_parse_plugins = True
+
+    FUNCTION_PATH = esm_rcfile.EsmToolsDir("FUNCTION_PATH")
+    recipe = FUNCTION_PATH + "esm_software/esm_runscripts/esm_runscripts.yaml"
+    need_to_parse_recipe = True
+    plugins_bare = FUNCTION_PATH + "/esm_software/esm_runscripts/esm_plugins.yaml"
+    need_to_parse_plugins = True
 
     framework_recipe = esm_plugin_manager.read_recipe(
         recipe, {"job_type": job_type}, need_to_parse_recipe

--- a/esm_runscripts/sim_objects.py
+++ b/esm_runscripts/sim_objects.py
@@ -165,10 +165,8 @@ class SimulationSetup(object):
 
 
     def add_esm_runscripts_defaults_to_config(self, config):
-        if config['general'].get("use_venv") or esm_rcfile.FUNCTION_PATH.startswith("NONE_YET"):
-            path_to_file = esm_tools.get_config_filepath("esm_software/esm_runscripts/defaults.yaml")
-        else:
-            path_to_file = esm_rcfile.FUNCTION_PATH + "/esm_software/esm_runscripts/defaults.yaml"
+        FUNCTION_PATH = esm_rcfile.EsmToolsDir("FUNCTION_PATH")
+        path_to_file = FUNCTION_PATH + "/esm_software/esm_runscripts/defaults.yaml"
         default_config = esm_parser.yaml_file_to_dict(path_to_file)
         config["general"]["defaults.yaml"] = default_config
         config = self.distribute_per_model_defaults(config)


### PR DESCRIPTION
This merge uses the new `esm_rcfile.EsmToolsDir` class to cleanup the code from the lines that evaluate whether the run is open or in a virtual environment, and assigns the correct paths to `esm_tools` package directories.

Tested for AWICM-3 and AWICM-1, both for open run and virtual environment.

See testing comments in esm-tools/esm_parser#25