### PR TITLE
some improvements for better readability

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.0.16"
+__version__ = "5.0.17"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/compute.py
+++ b/esm_runscripts/compute.py
@@ -153,9 +153,9 @@ def modify_namelists(config):
 
     if config["general"]["verbose"]:
         six.print_("\n" "- Setting up namelists for this run...")
-        for model in config["general"]["valid_model_names"]:
-            six.print_("-" * 80)
-            six.print_("* %s" % config[model]["model"], "\n")
+        for index, model in enumerate(config["general"]["valid_model_names"]):
+            print(f'{index+1}) {config[model]["model"]}')
+        print()
 
     for model in config["general"]["valid_model_names"]:
         config[model] = Namelist.nmls_load(config[model])
@@ -168,13 +168,12 @@ def modify_namelists(config):
         )
 
     if config["general"]["verbose"]:
-        print("end of namelist section")
+        print("::: end of namelist section\n")
     return config
 
 
 def copy_files_to_thisrun(config):
     if config["general"]["verbose"]:
-        six.print_("=" * 80, "\n")
         six.print_("PREPARING EXPERIMENT")
         # Copy files:
         six.print_("\n" "- File lists populated, proceeding with copy...")
@@ -191,7 +190,6 @@ def copy_files_to_thisrun(config):
 
 def copy_files_to_work(config):
     if config["general"]["verbose"]:
-        six.print_("=" * 80, "\n")
         six.print_("PREPARING WORK FOLDER")
     config = copy_files(
         config, config["general"]["in_filetypes"], source="thisrun", target="work"

--- a/esm_runscripts/filelists.py
+++ b/esm_runscripts/filelists.py
@@ -416,6 +416,8 @@ def replace_year_placeholder(config):
 
 
 def log_used_files(config):
+    if config["general"]["verbose"]:
+        print("\n::: Logging used files")
     filetypes = config["general"]["relevant_filetypes"]
     for model in config["general"]["valid_model_names"] + ["general"]:
         with open(
@@ -454,12 +456,11 @@ def log_used_files(config):
                             + config[model][filetype + "_targets"][category]
                         )
                         if config["general"]["verbose"]:
-                            print(
-                                "-  "
-                                + config[model][filetype + "_targets"][category]
-                                + " : "
-                                + config[model][filetype + "_sources"][category]
-                            )
+                            print()
+                            print((f'- source: '
+                                f'{config[model][filetype + "_sources"][category]}'))
+                            print((f'- target: '
+                                f'{config[model][filetype + "_targets"][category]}'))
                         flist.write("\n")
                 flist.write("\n")
                 flist.write(80 * "-")
@@ -541,6 +542,8 @@ def resolve_symlinks(file_source):
 
 
 def copy_files(config, filetypes, source, target):
+    if config["general"]["verbose"]:
+        print("\n::: Copying files")
 
     successful_files = []
     missing_files = {}
@@ -584,8 +587,9 @@ def copy_files(config, filetypes, source, target):
                             )
                     file_target = os.path.normpath(targetblock[categ])
                     if config["general"]["verbose"]:
-                        print(f"source: {file_source}")
-                        print(f"   --> target: {file_target}")
+                        print()
+                        print(f"- source: {file_source}")
+                        print(f"- target: {file_target}")
                     if file_source == file_target:
                         if config["general"]["verbose"]:
                             print(
@@ -602,7 +606,7 @@ def copy_files(config, filetypes, source, target):
                                 # (same as with ``mkdir -p <directory>>``)
                                 os.makedirs(dest_dir)
                             if not os.path.isfile(file_source):
-                                print(f"File not found: {file_source}...")
+                                print(f"WARNING: File not found: {file_source}")
                                 missing_files.update({file_target: file_source})
                                 continue
                             if os.path.isfile(file_target) and filecmp.cmp(
@@ -626,27 +630,28 @@ def copy_files(config, filetypes, source, target):
         if not "files_missing_when_preparing_run" in config["general"]:
             config["general"]["files_missing_when_preparing_run"] = {}
         if config["general"]["verbose"]:
-            six.print_("--- WARNING: These files were missing:")
+            six.print_("\n\nWARNING: These files were missing:")
             for missing_file in missing_files:
-                print("  - " + missing_file + ": " + missing_files[missing_file])
+                print(f'- missing source: {missing_files[missing_file]}')
+                print(f'- missing target: {missing_file}') 
+                print()
         config["general"]["files_missing_when_preparing_run"].update(missing_files)
     return config
 
 
 def report_missing_files(config):
+    # this list is populated by the ``copy_files`` function in filelists.py
     if "files_missing_when_preparing_run" in config["general"]:
         config = _check_fesom_missing_files(config)
         if not config["general"]["files_missing_when_preparing_run"] == {}:
-            six.print_(80 * "=")
             print("MISSING FILES:")
         for missing_file in config["general"]["files_missing_when_preparing_run"]:
-            print("--  " + missing_file + ": ")
-            print(
-                "        --> "
-                + config["general"]["files_missing_when_preparing_run"][missing_file]
-            )
+            print()
+            print(f'- missing source: {config["general"]["files_missing_when_preparing_run"][missing_file]}')
+            print(f'- missing target: {missing_file}')
         if not config["general"]["files_missing_when_preparing_run"] == {}:
             six.print_(80 * "=")
+        print()
     return config
 
 

--- a/esm_runscripts/namelists.py
+++ b/esm_runscripts/namelists.py
@@ -207,8 +207,8 @@ class Namelist:
             else:
                 disturbance_file = None
                 if config["general"]["verbose"]:
-                    print(
-                        config["general"]["experiment_scripts_dir"]
+                    print("WARNING: "
+                        + config["general"]["experiment_scripts_dir"]
                         + "/disturb_years.dat",
                         "was not found",
                     )
@@ -288,9 +288,12 @@ class Namelist:
         for nml_name, nml_obj in six.iteritems(mconfig.get("namelists", {})):
             all_nmls[nml_name] = nml_obj  # PG: or a string representation?
         for nml_name, nml in all_nmls.items():
-            six.print_("Final Contents of ", nml_name, ":")
+            message = f'\nFinal Contents of {nml_name}:'
+            six.print_(message)
+            six.print_(len(message) * '-')
             nml.write(sys.stdout)
-            six.print_("\n", 40 * "+ ")
+            print('-' * 80)
+            print(f'::: end of the contents of {nml_name}\n')
         return mconfig
 
     

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.16
+current_version = 5.0.17
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="5.0.16",
+    version="5.0.17",
     zip_safe=False,
 )


### PR DESCRIPTION
This was actually a part of a bigger commit but I wanted to push this earlier to isolate the changes.

The aim of this commit is making the output of the runscripts more readable, especially when the `verbose` mode is enabled. These are very useful when debugging a run or just skimming through. Your eyes will thank me later 🤓 

The attachment contains examples of both the default and current output (for the same run) for comparison. 
[better_output.log](https://github.com/esm-tools/esm_runscripts/files/6172324/better_output.log)
[default_output.log](https://github.com/esm-tools/esm_runscripts/files/6172325/default_output.log)

A similar pull request is also made to `esm_plugin_manager` (https://github.com/esm-tools/esm_plugin_manager/pull/3)

Here are some of the improvements.

### 1. Recipe steps are more explanatory:

- #### Before:

```
_read_date_file
---------------
```

- #### After:
```
==============================================================================
::: Executing the step:  _read_date_file    (step [1/13] of the job:  prepare)
==============================================================================
```

&nbsp;

### 2. `log_used_files` has a more readable output:

- #### Before: (I doesn't even fit on a single line)
```
-  /pf/a/a271096/better_output_test/test/run_20000401-20000430/work/echam6 : /pf/a/a270152/model_codes/echam-6.3.04p1//bin/echam6
-  /pf/a/a271096/better_output_test/test/run_20000401-20000430/work/namelist.echam : /pf/a/a271096/esm_all_packages/esm_tools/namelists/echam/6.3.04p1/PI-CTRL/namelist.echam
```

- #### After:
```
- source: /pf/a/a270152/model_codes/echam-6.3.04p1//bin/echam6
- target: /pf/a/a271096/better_output_test/test/run_20000401-20000430/work/echam6

- source: /pf/a/a271096/esm_all_packages/esm_tools/namelists/echam/6.3.04p1/PI-CTRL/namelist.echam
- target: /pf/a/a271096/better_output_test/test/run_20000401-20000430/work/namelist.echam
```

&nbsp;

### 3. Same with the `copy_files_to_thisrun`:

- #### Before: (If there are missing files, they are hard to spot and output is very messy)

```
source: /pool/data/ECHAM6/input/r0007/T63/T63TP04_piControl-LR_sst_1880-2379.nc
   --> target: /pf/a/a271096/better_output_test/test/run_20000401-20000430/forcing/echam/unit.20
File not found: /pool/data/ECHAM6/input/r0007/T63/T63TP04_piControl-LR_sst_1880-2379.nc...
source: /pool/data/ECHAM6/input/r0007/T63/T63TP04_piControl-LR_sic_1880-2379.nc
   --> target: /pf/a/a271096/better_output_test/test/run_20000401-20000430/forcing/echam/unit.96
File not found: /pool/data/ECHAM6/input/r0007/T63/T63TP04_piControl-LR_sic_1880-2379.nc...

```
- #### After:

```
- source: /pool/data/ECHAM6/input/r0007/T63/T63TP04_piControl-LR_sst_1880-2379.nc
- target: /pf/a/a271096/better_output_test/test/run_20000401-20000430/forcing/echam/unit.20
WARNING: File not found: /pool/data/ECHAM6/input/r0007/T63/T63TP04_piControl-LR_sst_1880-2379.nc

- source: /pool/data/ECHAM6/input/r0007/T63/T63TP04_piControl-LR_sic_1880-2379.nc
- target: /pf/a/a271096/better_output_test/test/run_20000401-20000430/forcing/echam/unit.96
WARNING: File not found: /pool/data/ECHAM6/input/r0007/T63/T63TP04_piControl-LR_sic_1880-2379.nc
```
