### PR TITLE
Hotfix/wildcards renaming to target

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.0.17"
+__version__ = "5.0.18"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/filelists.py
+++ b/esm_runscripts/filelists.py
@@ -269,7 +269,7 @@ def target_subfolders(config):
                                 + "/"
                                 + source_filename.split("/")[-1]
                             )
-                        elif "*" in filename:
+                        else:
                             # Get the general description of the filename
                             gen_descr = descr.split("_glob_")[0]
                             # Load the wild cards from source and target and split them
@@ -293,15 +293,11 @@ def target_subfolders(config):
                             # Loop through the pieces of the wild cards to create
                             # the correct target name by substituting in the source
                             # name
-                            target_name = source_filename.split("/")[-1]
+                            target_name = source_filename
                             for wcs, wct in zip(wild_card_source, wild_card_target):
                                 target_name = target_name.replace(wcs, wct)
                             # Return the correct target name
                             config[model][filetype + "_targets"][descr] = target_name
-                        else:
-                            config[model][filetype + "_targets"][
-                                descr
-                            ] = source_filename.split("/")[-1]
                     elif filename.endswith("/"):
                         source_filename = os.path.basename(
                             config[model][filetype + "_sources"][descr]

--- a/esm_runscripts/filelists.py
+++ b/esm_runscripts/filelists.py
@@ -207,6 +207,12 @@ def globbing(config):
                 ):  # * only in targets if denotes subfolder
                     if "*" in filename:
                         del config[model][filetype + "_sources"][descr]
+                        # Save the wildcard string for later use when copying to target
+                        wild_card = config[model].get(
+                            f"{filetype}_sources_wild_card", {}
+                        )
+                        wild_card[descr] = filename.split("/")[-1]
+                        config[model][filetype + "_sources_wild_card"] = wild_card
                         # skip subdirectories in file list, otherwise they
                         # will be listed as missing files later on
                         all_filenames = [f for f in glob.glob(filename) if not os.path.isdir(f)]
@@ -258,9 +264,40 @@ def target_subfolders(config):
                                 descr
                             ] = filename.replace("*", source_filename)
                         elif "/" in filename:
-                            config[model][filetype + "_targets"][
-                                descr
-                            ] = "/".join(filename.split("/")[:-1]) + "/" + source_filename.split("/")[-1]
+                            config[model][filetype + "_targets"][descr] = (
+                                "/".join(filename.split("/")[:-1])
+                                + "/"
+                                + source_filename.split("/")[-1]
+                            )
+                        elif "*" in filename:
+                            # Get the general description of the filename
+                            gen_descr = descr.split("_glob_")[0]
+                            # Load the wild cards from source and target and split them
+                            # at the *
+                            wild_card_source_all = config[model][
+                                f"{filetype}_sources_wild_card"
+                            ]
+                            wild_card_source = wild_card_source_all[gen_descr].split(
+                                "*"
+                            )
+                            wild_card_target = filename.split("*")
+                            if len(wild_card_target) != len(wild_card_source):
+                                esm_parser.user_error(
+                                    "Wild card",
+                                    (
+                                        "The wild card pattern of the source "
+                                        + f"{wild_card_source} does not match with the "
+                                        + f"target {wild_card_target}."
+                                    ),
+                                )
+                            # Loop through the pieces of the wild cards to create
+                            # the correct target name by substituting in the source
+                            # name
+                            target_name = source_filename.split("/")[-1]
+                            for wcs, wct in zip(wild_card_source, wild_card_target):
+                                target_name = target_name.replace(wcs, wct)
+                            # Return the correct target name
+                            config[model][filetype + "_targets"][descr] = target_name
                         else:
                             config[model][filetype + "_targets"][
                                 descr

--- a/esm_runscripts/filelists.py
+++ b/esm_runscripts/filelists.py
@@ -281,13 +281,16 @@ def target_subfolders(config):
                                 "*"
                             )
                             wild_card_target = filename.split("*")
+                            # Check for syntax mistakes
                             if len(wild_card_target) != len(wild_card_source):
                                 esm_parser.user_error(
                                     "Wild card",
                                     (
                                         "The wild card pattern of the source "
                                         + f"{wild_card_source} does not match with the "
-                                        + f"target {wild_card_target}."
+                                        + f"target {wild_card_target}. Make sure the "
+                                        + f"that the number of * are the same in both "
+                                        + f"sources and targets."
                                     ),
                                 )
                             # Loop through the pieces of the wild cards to create

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.17
+current_version = 5.0.18
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="5.0.17",
+    version="5.0.18",
     zip_safe=False,
 )


### PR DESCRIPTION
A fix to allow renaming during copying into targets when using wildcards.

For example, in awicm3 we have the following restart files:
```
<exp_path>/restart/oifs/DATE/srf0006.*
```
and we want them to end in the next run work directory as `srf0003.*` such as:
```
<exp_path>/run_DATE/work/srf0003.*
```

This fix allows this type of operation as long as the source key in the yaml file has a consistent number of `*` with the target key.