### PR TITLE
Feature/prev run

### DIFF
--- a/esm_runscripts/compute.py
+++ b/esm_runscripts/compute.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+import copy
 
 import esm_rcfile
 import six
@@ -324,7 +325,10 @@ def _write_finalized_config(config):
         + "_finished_config.yaml",
         "w",
     ) as config_file:
-        out = yaml.dump(config)
+        # Avoid saving ``prev_run`` information in the config file
+        config_final = copy.deepcopy(config)
+        del config_final["prev_run"]
+        out = yaml.dump(config_final)
         out = strip_python_tags(out)
         config_file.write(out)
     return config

--- a/esm_runscripts/filelists.py
+++ b/esm_runscripts/filelists.py
@@ -288,7 +288,7 @@ def target_subfolders(config):
                                 + "/"
                                 + source_filename.split("/")[-1]
                             )
-                        elif "*" in filename:
+                        else:
                             # Get the general description of the filename
                             gen_descr = descr.split("_glob_")[0]
                             # Load the wild cards from source and target and split them
@@ -312,15 +312,11 @@ def target_subfolders(config):
                             # Loop through the pieces of the wild cards to create
                             # the correct target name by substituting in the source
                             # name
-                            target_name = source_filename.split("/")[-1]
+                            target_name = source_filename
                             for wcs, wct in zip(wild_card_source, wild_card_target):
                                 target_name = target_name.replace(wcs, wct)
                             # Return the correct target name
                             config[model][filetype + "_targets"][descr] = target_name
-                        else:
-                            config[model][filetype + "_targets"][
-                                descr
-                            ] = source_filename.split("/")[-1]
                     elif filename.endswith("/"):
                         source_filename = os.path.basename(
                             config[model][filetype + "_sources"][descr]

--- a/esm_runscripts/prepare.py
+++ b/esm_runscripts/prepare.py
@@ -544,7 +544,7 @@ def set_prev_date(config):
                 0,
                 int(config[model]["time_step"]),
             )
-            config[model]["last_parent_date"] = config[model]["parent_date"] - (
+            config[model]["last_parent_date"] = config[model]["prev_date"] - (
                 0,
                 0,
                 0,
@@ -569,7 +569,7 @@ def set_prev_date(config):
                 0,
                 int(dt),
             )
-            config[model]["last_parent_date"] = config[model]["parent_date"] - (
+            config[model]["last_parent_date"] = config[model]["prev_date"] - (
                 0,
                 0,
                 0,

--- a/esm_runscripts/prepare.py
+++ b/esm_runscripts/prepare.py
@@ -544,6 +544,14 @@ def set_prev_date(config):
                 0,
                 int(config[model]["time_step"]),
             )
+            config[model]["last_parent_date"] = config[model]["parent_date"] - (
+                0,
+                0,
+                0,
+                0,
+                0,
+                int(config[model]["time_step"]),
+            )
 
         # NOTE(PG, MAM): Here we check if the time step still has a variable which might be set in a different model, and resolve this case
         elif "time_step" in config[model] and (
@@ -554,6 +562,14 @@ def set_prev_date(config):
                 model, config[model]["time_step"], config, [], []
             )
             config[model]["prev_date"] = config["general"]["current_date"] - (
+                0,
+                0,
+                0,
+                0,
+                0,
+                int(dt),
+            )
+            config[model]["last_parent_date"] = config[model]["parent_date"] - (
                 0,
                 0,
                 0,

--- a/esm_runscripts/sim_objects.py
+++ b/esm_runscripts/sim_objects.py
@@ -285,8 +285,8 @@ class PrevRunInfo(dict):
     """
     A dictionary subclass to access information from the previous run. The object is
     created in the ``SimulationSetup`` class in ``self.config["prev_run"]``. The idea
-    behind this class is that variables from the previous simulation can be called from
-    the yaml files with a very similar syntax as one would do for the current run.
+    behind this class is that variables from the previous run can be called from the
+    yaml files with a very similar syntax as one would do for the current run.
 
     The syntax is as follows:
 
@@ -305,8 +305,8 @@ class PrevRunInfo(dict):
 
     .. Warning:: Use this feature only when there is no other way of accessing the
        information needed. Note that, for example, dates of the previous run are
-       available under variables such as ``last_start_date``, ``parent_start_date``,
-       etc.
+       already available in the current run, under variables such as
+       ``last_start_date``, ``parent_start_date``, etc.
     """
 
     def __init__(self, config = {"general": {}}):
@@ -379,7 +379,7 @@ class PrevRunInfo(dict):
     def value_in_prev_run_config(self, key):
         """
         If the ``last_run_datestamp`` exists at this poing in the current ``config``,
-        try to load the previous config file to access the ``key``.
+        tries to load the previous config file to access the ``key``.
         """
 
         value = None

--- a/esm_runscripts/sim_objects.py
+++ b/esm_runscripts/sim_objects.py
@@ -315,6 +315,7 @@ class PrevRunInfo(dict):
         """
         self._config = config
         self._prev_config = None
+        self.__setitem__("NONE_YET", {})
 
 
     def __getitem__(self, key):

--- a/esm_runscripts/sim_objects.py
+++ b/esm_runscripts/sim_objects.py
@@ -3,14 +3,14 @@ Documentation goes here
 """
 import pdb
 import os
+import yaml
 
 from loguru import logger
 
 import esm_tools
 import esm_parser
-
-
 import esm_rcfile
+
 
 from . import batch_system, compute, helpers, prepare, tidy
 
@@ -39,6 +39,7 @@ class SimulationSetup(object):
             self.config["general"]["jobtype"] = "inspect"
             self.config["general"]["reset_calendar_to_last"] = True
 
+        self.config["prev_run"] = PrevRunInfo(self.config)
         self.config = prepare.run_job(self.config)
 
 
@@ -278,3 +279,141 @@ class SimulationSetup(object):
             #self.config["general"]["post_task_list"] = post_task_list
             batch_system.write_simple_runscript(self.config)
             self.config = batch_system.submit(self.config)
+
+
+class PrevRunInfo(dict):
+    """
+    A dictionary subclass to access information from the previous run. The object is
+    created in the ``SimulationSetup`` class in ``self.config["prev_run"]``. The idea
+    behing this class is that variables from the previous simulation can be called from
+    the yaml files with a very similar syntax as one would do for the current run.
+
+    The syntax is as follows:
+
+    .. code-block:: yaml
+
+       <your_var>: ${prev_run.<path>.<to>.<var>}
+
+    For example, let's assume we want to access the `time_step` from the previous run
+    of a `FESOM` simulation and store it in a variable called `prev_time_step`:
+
+    .. code-block:: yaml
+
+       prev_time_step: ${prev_run.fesom.time_step}
+
+    .. Note:: Only the single previous simulation loaded
+
+    .. Warning:: Use this feature only when there is no other way of accessing the
+       information needed. Note that, for example, dates of the previous run are
+       available under variables such as ``last_start_date``, ``parent_start_date``,
+       etc.
+    """
+
+    def __init__(self, config = {"general": {}}):
+        """
+        Links the current ``config`` to the object.
+        """
+        self._config = config
+        self._prev_config = None
+
+
+    def __getitem__(self, key):
+        """
+        Defines the special behaviour for accessing a ``key`` of the object (i.e. when
+        the object is called such as ``<object>[key]``). If ``_prev_config`` is already
+        loaded returns the value of the ``key``. Otherwise, it tries to load
+        ``_prev_config`` and if not possible yet, returns a ``PrevRunInfo`` instance.
+        """
+        # If the previous config is loaded return the key
+        if self._prev_config:
+            return self._prev_config[key]
+        # Otherwise, try to find the value
+        else:
+            # Try getting the value in the standard way
+            try:
+                value = super().__getitem__(key)
+            except KeyError:
+                # If the key does not exist try to find the previous config file and
+                # return the value
+                value = self.value_in_prev_run_config(key)
+                # If the value is still not found return an instance of ``PrevRunInfo``
+                if not value:
+                    value = PrevRunInfo()
+
+            return value
+
+
+    def get(self, *args, **kwargs):
+        """
+        Defines the special behaviour for the ``get`` method of the object (i.e. when
+        the object is called such as ``<object>.get(key, <value>)``). If
+        ``_prev_config`` is already loaded returns the value of the ``key``. Otherwise,
+        it tries to load it from ``_prev_config`` and if not possible yet, returns
+        ``None`` if no second argument is defined for the ``get``, or it returns the
+        second argument, just as a standard ``<dict>.get`` would do.
+        """
+
+        key = args[0]
+        prev_config = {}
+        prev_value = None
+        # If the previous configuration is already loaded use the standard ``get``
+        if self._prev_config:
+            prev_config = self._prev_config
+        # If the previous config is not yet loaded try to load it from the previous
+        # config file
+        else:
+            try:
+                prev_value = self.value_in_prev_run_config(key)
+            except KeyError:
+                # This is a get, so if the key does not exists that's ok
+                pass
+        # Define the value
+        value = prev_config.get(*args, **kwargs)
+        if prev_value:
+            value = prev_value
+
+        return value
+
+
+    def value_in_prev_run_config(self, key):
+        """
+        If the ``last_run_datestamp`` exists at this poing in the current ``config``,
+        try to load the previous config file to access the ``key``.
+        """
+
+        value = None
+        general = self._config.get("general")
+        # If the config already includes the date stamp then load the previous config
+        # file and return the corresponding value to the key
+        if "last_run_datestamp" in general:
+            # Build name of the file
+            prev_run_config_file = (
+                general["experiment_config_dir"] +
+                general["expid"] +
+                "_finished_config.yaml_" +
+                general["last_run_datestamp"]
+            )
+            # If the file exist, load the file content
+            if os.path.isfile(prev_run_config_file):
+                with open(prev_run_config_file, "r") as prev_file:
+                    prev_config = yaml.load(prev_file, Loader=yaml.FullLoader)
+                self._prev_config = prev_config["dictitems"]
+                # In case a ``prev_run`` info exists inside the file, remove it to
+                # avoid config files from getting huge (prev_run nested inside
+                # prev_run...)
+                if "prev_run" in self._prev_config:
+                    del self._prev_config["prev_run"]
+                # Check that the data really comes from the previous run
+                this_run_number = self._config["general"]["run_number"]
+                prev_run_number = self._prev_config["general"]["run_number"]
+                if this_run_number - 1 != prev_run_number:
+                    print(
+                        "Error: incorrect file loaded as previous configuration:\n"
+                        + f"    File loaded: {prev_run_config_file}\n"
+                        + f"    This run number: {this_run_number}\n"
+                        + f"    Previous run number: {prev_run_number}\n"
+                    )
+                    sys.exit(1)
+                value = self._prev_config[key]
+
+        return value

--- a/esm_runscripts/sim_objects.py
+++ b/esm_runscripts/sim_objects.py
@@ -285,7 +285,7 @@ class PrevRunInfo(dict):
     """
     A dictionary subclass to access information from the previous run. The object is
     created in the ``SimulationSetup`` class in ``self.config["prev_run"]``. The idea
-    behing this class is that variables from the previous simulation can be called from
+    behind this class is that variables from the previous simulation can be called from
     the yaml files with a very similar syntax as one would do for the current run.
 
     The syntax is as follows:


### PR DESCRIPTION
This pull request adds the `RunPrevInfo` class to `sim_objects.py`, a dictionary subclass to access information from the previous run. The object is created in the ``SimulationSetup`` class in ``self.config["prev_run"]``. The idea behind this class is that variables from the previous simulation can be called from the yaml files with a very similar syntax as one would do for the current run.

The syntax is as follows:
```
<your_var>: ${prev_run.<path>.<to>.<var>}
```
For example, let's assume we want to access the `time_step` from the previous run of a `FESOM` simulation and store it in a variable called `prev_time_step`:
```
prev_time_step: ${prev_run.fesom.time_step}
```
Note: Only the single previous simulation loaded

This is important for AWICM3, for copying and renaming restart files when OIFS is cheated to think it is always running the second leg, otherwise it meets a memory problem in log runs (a well known OIFS issue). The problem of cheating OIFS in this manner is that previous leg restart files names depend on some information existing in the previous run but not in the current run, so the previous config needs to be accessed somehow.