### PR TITLE
minifeature/pre run commands

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.0"
+__version__ = "5.1.1"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/batch_system.py
+++ b/esm_runscripts/batch_system.py
@@ -5,6 +5,7 @@ import sys
 import esm_environment
 import six
 
+from esm_parser import user_error
 from . import helpers
 from .slurm import Slurm
 from .pbs import Pbs
@@ -192,6 +193,23 @@ class batch_system:
             extras.append("source "+config["general"]["experiment_dir"]+"/.venv_esmtools/bin/activate")
         if config["general"].get("funny_comment", True):
             extras.append("# 3...2...1...Liftoff!")
+        # Search for ``pre_run_commands``s in the components
+        for component in config.keys():
+            pre_run_commands = config[component].get("pre_run_commands")
+            if isinstance(pre_run_commands, list):
+                for pr_command in pre_run_commands:
+                    extras.append(pr_command)
+            elif isinstance(pre_run_commands, str):
+                extras.append(pre_run_commands)
+            elif pre_run_commands==None:
+                continue
+            else:
+                user_error('Invalid type for "pre_run_commands"', (
+                    f'"{type(pre_run_commands)}" type is not supported for '
+                    f'"pre_run_commands" defined in "{component}". Please, define ' +
+                    '"pre_run_commands" as a "string" or a "list".'
+                )
+                )
         return extras
 
     @staticmethod

--- a/esm_runscripts/batch_system.py
+++ b/esm_runscripts/batch_system.py
@@ -198,16 +198,25 @@ class batch_system:
             pre_run_commands = config[component].get("pre_run_commands")
             if isinstance(pre_run_commands, list):
                 for pr_command in pre_run_commands:
-                    extras.append(pr_command)
+                    if isinstance(pr_command, str):
+                        extras.append(pr_command)
+                    else:
+                        user_error('Invalid type for "pre_run_commands"', (
+                            f'"{type(pr_command)}" type is not supported for ' +
+                            f'elements of the "pre_run_commands", defined in ' +
+                            f'"{component}". Please, define ' +
+                            '"pre_run_commands" as a "list" of "strings" or a "list".'
+                        )
+                        )
             elif isinstance(pre_run_commands, str):
                 extras.append(pre_run_commands)
             elif pre_run_commands==None:
                 continue
             else:
                 user_error('Invalid type for "pre_run_commands"', (
-                    f'"{type(pre_run_commands)}" type is not supported for '
+                    f'"{type(pre_run_commands)}" type is not supported for ' +
                     f'"pre_run_commands" defined in "{component}". Please, define ' +
-                    '"pre_run_commands" as a "string" or a "list".'
+                    '"pre_run_commands" as a "string" or a "list" of "strings".'
                 )
                 )
         return extras

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.0
+current_version = 5.1.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="5.1.0",
+    version="5.1.1",
     zip_safe=False,
 )


### PR DESCRIPTION
added the variable `pre_run_commands` to specify commands on the .sad file to be written before the run calls. It can be defined inside any component and inside any yaml file as either a string or a list of strings