### PR TITLE
symlinks: may the force be with you

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.6"
+__version__ = "5.1.7"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/helpers.py
+++ b/esm_runscripts/helpers.py
@@ -7,6 +7,7 @@ import esm_rcfile
 
 import esm_plugin_manager
 import esm_tools
+import esm_parser
 
 
 def symlink(target, link_name, overwrite=False):
@@ -20,7 +21,12 @@ def symlink(target, link_name, overwrite=False):
     '''
 
     if not overwrite:
-        os.symlink(target, link_name)
+        try:
+            os.symlink(target, link_name)
+        except FileExistsError:
+            error_type = "File Exists"
+            error_text = f"{link_name} already exists. Use overwrite=True"
+            esm_parser.user_error(error_type, error_text, exit_code=1)
         return
 
     # os.replace() may fail if files are on different filesystems
@@ -45,10 +51,13 @@ def symlink(target, link_name, overwrite=False):
         if not os.path.islink(link_name) and os.path.isdir(link_name):
             raise IsADirectoryError(f"Cannot symlink over existing directory: '{link_name}'")
         os.replace(temp_link_name, link_name)
-    except:
+    except Exception as e:
         if os.path.islink(temp_link_name):
             os.remove(temp_link_name)
-        raise
+        error_type = "Error"
+        error_text = repr(e)
+        esm_parser.user_error(error_type, error_text, exit_code=1)
+        
 
 
 def vprint(message, config):

--- a/esm_runscripts/helpers.py
+++ b/esm_runscripts/helpers.py
@@ -1,10 +1,54 @@
 import sys
 from datetime import datetime
+import os
+import tempfile
 
 import esm_rcfile
 
 import esm_plugin_manager
 import esm_tools
+
+
+def symlink(target, link_name, overwrite=False):
+    '''
+    unfortunately Python os.symlink does not have a force option. So, this is a
+    good workaround.
+    source: https://stackoverflow.com/questions/8299386/modifying-a-symlink-in-python/55742015#55742015
+    Create a symbolic link named link_name pointing to target.
+    If link_name exists then FileExistsError is raised, unless overwrite=True.
+    When trying to overwrite a directory, IsADirectoryError is raised.
+    '''
+
+    if not overwrite:
+        os.symlink(target, link_name)
+        return
+
+    # os.replace() may fail if files are on different filesystems
+    link_dir = os.path.dirname(link_name)
+
+    # Create link to target with temporary filename
+    while True:
+        temp_link_name = tempfile.mktemp(dir=link_dir)
+
+        # os.* functions mimic as closely as possible system functions
+        # The POSIX symlink() returns EEXIST if link_name already exists
+        # https://pubs.opengroup.org/onlinepubs/9699919799/functions/symlink.html
+        try:
+            os.symlink(target, temp_link_name)
+            break
+        except FileExistsError:
+            pass
+
+    # Replace link_name with temp_link_name
+    try:
+        # Pre-empt os.replace on a directory with a nicer message
+        if not os.path.islink(link_name) and os.path.isdir(link_name):
+            raise IsADirectoryError(f"Cannot symlink over existing directory: '{link_name}'")
+        os.replace(temp_link_name, link_name)
+    except:
+        if os.path.islink(temp_link_name):
+            os.remove(temp_link_name)
+        raise
 
 
 def vprint(message, config):

--- a/esm_runscripts/helpers.py
+++ b/esm_runscripts/helpers.py
@@ -57,7 +57,6 @@ def symlink(target, link_name, overwrite=False):
         error_type = "Error"
         error_text = repr(e)
         esm_parser.user_error(error_type, error_text, exit_code=1)
-        
 
 
 def vprint(message, config):

--- a/esm_runscripts/sim_objects.py
+++ b/esm_runscripts/sim_objects.py
@@ -243,9 +243,11 @@ class SimulationSetup(object):
 
             self.config["general"]["monitor_file"] = monitor_file
             if os.path.isfile(monitor_file_path):
-                os.symlink(monitor_file_path, monitor_file_in_run)
+                # os.symlink(monitor_file_path, monitor_file_in_run)
+                helpers.symlink(monitor_file_path, monitor_file_in_run, overwrite=True)
             if os.path.isfile(exp_log_path):
-                os.symlink(exp_log_path, log_in_run)
+                # os.symlink(exp_log_path, log_in_run)
+                helpers.symlink(exp_log_path, log_in_run, overwrite=True)
             self.config = tidy.run_job(self.config)
 
         helpers.end_it_all(self.config)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.6
+current_version = 5.1.7
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="5.1.6",
+    version="5.1.7",
     zip_safe=False,
 )


### PR DESCRIPTION
As Sebastian pointed out on Slack, we need force in symbolic linking (aka ln -sf). Eg. 
```bash
ln -s target link
ln -s target link  # this does not work: 'ln: creating symbolic link `link': File exists'
ln -sf target link  # but this does
```
Unfortunately Python `os.symlink` does not have force/overwrite option. While writing my own I found a upvoted solution on SO. I tested that on a separate code and seems to work.

I placed this function into `helpers.py`. esm_runscripts have many more `os.symlink` calls but I did not change them yet. I only changed the part that caused trouble to @seb-wahl.