### PR TITLE
Feature/handle sigint

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.8"
+__version__ = "5.1.9"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.10"
+__version__ = "5.1.11"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.7"
+__version__ = "5.1.8"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.9"
+__version__ = "5.1.10"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/batch_system.py
+++ b/esm_runscripts/batch_system.py
@@ -309,6 +309,7 @@ class batch_system:
                 + " -t tidy_and_resubmit -p ${process} -j "
                 + config["general"]["jobtype"]
                 + " -v "
+                + " --no-motd "
             )
             if "--open-run" in config["general"]["original_command"] or not config["general"].get("use_venv"):
                 tidy_call += " --open-run"

--- a/esm_runscripts/cli.py
+++ b/esm_runscripts/cli.py
@@ -2,6 +2,8 @@
 """
 A small wrapper that combines the shell interface and the Python interface
 """
+from . import event_handlers
+event_handlers.signal_listener()
 
 # Import from Python Standard Library
 import argparse

--- a/esm_runscripts/cli.py
+++ b/esm_runscripts/cli.py
@@ -112,6 +112,13 @@ def parse_shargs():
         default=False,
         action="store_true",
     )
+    
+    parser.add_argument(
+        "--no-motd",
+        help = "supress the printing of MOTD",
+        default = False,
+        action = "store_true" 
+    )
 
     return parser.parse_args()
 
@@ -131,6 +138,7 @@ def main():
     inspect = None
     use_venv = None
     modify_config_file = None
+    no_motd = False
 
     parsed_args = vars(ARGS)
 
@@ -164,6 +172,8 @@ def main():
         use_venv = not parsed_args["open_run"]
     if "modify" in parsed_args:
         modify_config_file = parsed_args["modify"]
+    if "no_motd" in parsed_args:
+        no_motd = parsed_args["no_motd"]
 
     command_line_config = {}
     command_line_config["check"] = check
@@ -177,6 +187,7 @@ def main():
     command_line_config["verbose"] = verbose
     command_line_config["inspect"] = inspect
     command_line_config["use_venv"] = use_venv
+    command_line_config["no_motd"] = no_motd
     if modify_config_file:
         command_line_config["modify_config_file"] = modify_config_file
 
@@ -197,6 +208,7 @@ def main():
         logger.debug("starting : ", jobtype)
 
     Setup = SimulationSetup(command_line_config)
-    if not Setup.config['general']['submitted']:
+    # if not Setup.config['general']['submitted']:
+    if not Setup.config['general']['submitted'] and not no_motd:
         check_all_esm_packages()
     Setup()

--- a/esm_runscripts/compute.py
+++ b/esm_runscripts/compute.py
@@ -538,6 +538,7 @@ def copy_tools_to_thisrun(config):
             + "; "
             + "esm_runscripts "
             + gconfig["original_command"].replace("-U", "")
+            + " --no-motd "
         )
         if config["general"]["verbose"]:
             print(restart_command)

--- a/esm_runscripts/database_actions.py
+++ b/esm_runscripts/database_actions.py
@@ -1,6 +1,6 @@
 from . import database
 from datetime import datetime
-
+import sqlalchemy
 
 def database_entry(config):
     if config["general"]["check"]:
@@ -28,25 +28,32 @@ def database_basic_entry(config):
     return thisrun
 
 
+def try_to_commit():
+    try:
+        database.session.commit()
+    except sqlalchemy.exc.OperationalError as e:
+        print("Sorry, there was some SQL Error!")
+        print(e)
+
 def database_entry_check(config):
     thisrun = database_basic_entry(config)
     thisrun.outcome = "check"
-    database.session.commit()
+    try_to_commit()
 
 
 def database_entry_start(config):
     thisrun = database_basic_entry(config)
     thisrun.outcome = "started"
-    database.session.commit()
+    try_to_commit()
 
 def database_entry_success(config):
     thisrun = database_basic_entry(config)
     thisrun.outcome = "success"
-    database.session.commit()
-    
+    try_to_commit()
+
 
 def database_entry_crashed(config):
     thisrun = database_basic_entry(config)
     thisrun.outcome = "crashed"
-    database.session.commit()
+    try_to_commit()
 

--- a/esm_runscripts/event_handlers.py
+++ b/esm_runscripts/event_handlers.py
@@ -28,11 +28,6 @@ def handle_sigint(signum, stack_frame):
     print()  # print a new line after ^C character (CTRL-C)
     sys.stderr.write('ctrl c is pressed. Terminating\n')
 
-    # these can be moved into a `if verbose` block
-    sys.stderr.write(f'- file:     {os.path.realpath(stack_frame.f_code.co_filename)}\n')
-    sys.stderr.write(f'- line:     {stack_frame.f_code.co_firstlineno}\n')
-    sys.stderr.write(f'- function: {stack_frame.f_code.co_name}\n')
-    
     # exit with 2 according to https://en.wikipedia.org/wiki/Signal_(IPC) 
     sys.exit(signal.SIGINT.value)  
             

--- a/esm_runscripts/event_handlers.py
+++ b/esm_runscripts/event_handlers.py
@@ -23,7 +23,9 @@ def handle_sigint(signum, stack_frame):
     stack_frame : Python frame object
         current stack frame
     
-    More info: https://docs.python.org/3/library/signal.html
+    Notes
+    -----
+        More info: https://docs.python.org/3/library/signal.html
     """
     print()  # print a new line after ^C character (CTRL-C)
     sys.stderr.write('ctrl c is pressed. Terminating\n')

--- a/esm_runscripts/event_handlers.py
+++ b/esm_runscripts/event_handlers.py
@@ -1,0 +1,41 @@
+import signal
+import sys
+import os
+
+def signal_listener():
+    """Listens to the signals (eg. CTRL-C press, ...) and calls the handler
+    for that signal"""
+    
+    # 1) handler for the SIGINT (CTRL-C)
+    signal.signal(signal.SIGINT, handle_sigint)
+    
+    # other signal handlers may go here, eg. SIGHUP, SIGSTOP, ...)
+    # each signal is handled by a function handle_<signal>, eg. handle_sigint()
+
+
+def handle_sigint(signum, stack_frame):
+    """Handles the SIGINT signal (aka CTRL-C press on UNIX/LINUX)
+    
+    Parameters
+    ----------
+    signum : int
+        signal number.
+    stack_frame : Python frame object
+        current stack frame
+    
+    More info: https://docs.python.org/3/library/signal.html
+    """
+    print()  # print a new line after ^C character (CTRL-C)
+    sys.stderr.write('ctrl c is pressed. Terminating\n')
+
+    # these can be moved into a `if verbose` block
+    sys.stderr.write(f'- file:     {os.path.realpath(stack_frame.f_code.co_filename)}\n')
+    sys.stderr.write(f'- line:     {stack_frame.f_code.co_firstlineno}\n')
+    sys.stderr.write(f'- function: {stack_frame.f_code.co_name}\n')
+    
+    # exit with 2 according to https://en.wikipedia.org/wiki/Signal_(IPC) 
+    sys.exit(signal.SIGINT.value)  
+            
+
+if __name__ == "__main__":
+    pass

--- a/esm_runscripts/pbs.py
+++ b/esm_runscripts/pbs.py
@@ -188,7 +188,7 @@ class Pbs:
                 launcher_flags = self.calc_launcher_flags(config, model)
                 # Substitute @MODEL@ with the model name
                 launcher_flags = launcher_flags.replace("@MODEL@", model.upper())
-                component_lines.append(f'{launcher_flags} ./{command} ')
+                component_lines.append(f"{launcher_flags} ./{command} ")
 
         # Merge each component flags and commands into a single string
         components = sep.join(component_lines)

--- a/esm_runscripts/pbs.py
+++ b/esm_runscripts/pbs.py
@@ -170,6 +170,13 @@ class Pbs:
         #    self.calc_requirements_multi_aprun(config)
         #    return
 
+        # Calculates the left justification for the prepend of stdout and stderr
+        model_name_lengths = [
+            len(model) for model in config["general"]["valid_model_names"]
+            if "execution_command" in config[model] or "executable" in config[model]
+        ]
+        prep_just = max(model_name_lengths) + 3
+
         component_lines = []
         # Read in the separator to be used in between component calls in the job
         # launcher
@@ -182,11 +189,17 @@ class Pbs:
                 command = config[model]["execution_command"]
             elif "executable" in config[model]:
                 command = config[model]["executable"]
-            # Calculate launcher flags
+            # Prepare the MPMD commands
             if command:
                 launcher = config["computer"].get("launcher")
                 launcher_flags = self.calc_launcher_flags(config, model)
-                component_lines.append(f"{launcher_flags} ./{command} ")
+                # stdout and stderr modifications to prepend [MODEL] to each line
+                prep_str = f"[{model}]".upper().ljust(prep_just)
+                prep_model_std_oe = (
+                    f"1> >(sed 's/^/{prep_str}/' >&1) " +
+                    f"2> >(sed 's/^/{prep_str}/' >&2)"
+                )
+                component_lines.append(f'{launcher_flags} bash -c "./{command} {prep_model_std_oe}" ')
 
         # Merge each component flags and commands into a single string
         components = sep.join(component_lines)

--- a/esm_runscripts/sim_objects.py
+++ b/esm_runscripts/sim_objects.py
@@ -34,7 +34,7 @@ class SimulationSetup(object):
         if "verbose" not in self.config["general"]:
             self.config["general"]["verbose"] = False
 
-        if command_line_config["no_motd"]:
+        if self.command_line_config.get("no_motd", False):
             self.config["general"]["no_motd"] = True
             
         # read the prepare recipe

--- a/esm_runscripts/sim_objects.py
+++ b/esm_runscripts/sim_objects.py
@@ -33,6 +33,10 @@ class SimulationSetup(object):
         self.config["general"]["command_line_config"] = self.command_line_config
         if "verbose" not in self.config["general"]:
             self.config["general"]["verbose"] = False
+
+        if command_line_config["no_motd"]:
+            self.config["general"]["no_motd"] = True
+            
         # read the prepare recipe
         self.config["general"]["reset_calendar_to_last"] = False
         if self.config["general"].get("inspect"):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.7
+current_version = 5.1.8
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.9
+current_version = 5.1.10
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.8
+current_version = 5.1.9
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.10
+current_version = 5.1.11
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="5.1.9",
+    version="5.1.10",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="5.1.8",
+    version="5.1.9",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="5.1.7",
+    version="5.1.8",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="5.1.10",
+    version="5.1.11",
     zip_safe=False,
 )


### PR DESCRIPTION
As @dbarbi mentioned today, pressing `CTRL-C` may result in an ugly list of traceback which is not something that we see in general Linux commands. I wrote a event listener and handler to solve that. Now, when you hit `CTRL-C` while `esm_runscripts` is running this will result in 
```bash
^C
ctrl c is pressed. Terminating
```

In the first commit, I actually placed some verbosity messages but then deleted them. They printed out the last element in the stack trace. If you don't want anything at all, then simply erase the `sys.stderr.write()` call.

If you hit `CTRL-C` in a nanosecond of course it will not be executed. I can also make a workaround but this requires some changes to the `setup.py`. There we need to provide our own binary executable instead of the default one that is provided by Python. I mean, we need to use `scripts` explicitly instead of the `console_scripts` `entry_points`. Then, I can explicitly have something like
```Python
#!/sw/rhel6-x64/conda/anaconda3-bleeding_edge/bin/python
# 1st line to execute in esm_runscripts from command line
import event_handlers
event_handlers.signal_listener()

# rest of it is the same as before as automatically generated by Python package builder

__requires__ = 'esm-runscripts'
import re
import sys
from pkg_resources import load_entry_point

if __name__ == '__main__':
    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
    sys.exit(
        load_entry_point('esm-runscripts', 'console_scripts', 'esm_runscripts')()
    )
```

It is also possible to extend this implementation for the other signals such as `CTRL-z` and so on. I can also use the samething in our other binaries such as `esm_master` and `esm_versions`. But for that, I think it is better to move these commands to a more common path for avoiding duplication.