### PR TITLE
supressing of MOTD

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.9"
+__version__ = "5.1.10"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/batch_system.py
+++ b/esm_runscripts/batch_system.py
@@ -309,6 +309,7 @@ class batch_system:
                 + " -t tidy_and_resubmit -p ${process} -j "
                 + config["general"]["jobtype"]
                 + " -v "
+                + " --no-motd "
             )
             if "--open-run" in config["general"]["original_command"] or not config["general"].get("use_venv"):
                 tidy_call += " --open-run"

--- a/esm_runscripts/cli.py
+++ b/esm_runscripts/cli.py
@@ -112,6 +112,13 @@ def parse_shargs():
         default=False,
         action="store_true",
     )
+    
+    parser.add_argument(
+        "--no-motd",
+        help = "supress the printing of MOTD",
+        default = False,
+        action = "store_true" 
+    )
 
     return parser.parse_args()
 
@@ -131,6 +138,7 @@ def main():
     inspect = None
     use_venv = None
     modify_config_file = None
+    no_motd = False
 
     parsed_args = vars(ARGS)
 
@@ -164,6 +172,8 @@ def main():
         use_venv = not parsed_args["open_run"]
     if "modify" in parsed_args:
         modify_config_file = parsed_args["modify"]
+    if "no_motd" in parsed_args:
+        no_motd = parsed_args["no_motd"]
 
     command_line_config = {}
     command_line_config["check"] = check
@@ -177,6 +187,7 @@ def main():
     command_line_config["verbose"] = verbose
     command_line_config["inspect"] = inspect
     command_line_config["use_venv"] = use_venv
+    command_line_config["no_motd"] = no_motd
     if modify_config_file:
         command_line_config["modify_config_file"] = modify_config_file
 
@@ -197,6 +208,7 @@ def main():
         logger.debug("starting : ", jobtype)
 
     Setup = SimulationSetup(command_line_config)
-    if not Setup.config['general']['submitted']:
+    # if not Setup.config['general']['submitted']:
+    if not Setup.config['general']['submitted'] and not no_motd:
         check_all_esm_packages()
     Setup()

--- a/esm_runscripts/compute.py
+++ b/esm_runscripts/compute.py
@@ -538,6 +538,7 @@ def copy_tools_to_thisrun(config):
             + "; "
             + "esm_runscripts "
             + gconfig["original_command"].replace("-U", "")
+            + " --no-motd "
         )
         if config["general"]["verbose"]:
             print(restart_command)

--- a/esm_runscripts/sim_objects.py
+++ b/esm_runscripts/sim_objects.py
@@ -33,6 +33,10 @@ class SimulationSetup(object):
         self.config["general"]["command_line_config"] = self.command_line_config
         if "verbose" not in self.config["general"]:
             self.config["general"]["verbose"] = False
+
+        if command_line_config["no_motd"]:
+            self.config["general"]["no_motd"] = True
+            
         # read the prepare recipe
         self.config["general"]["reset_calendar_to_last"] = False
         if self.config["general"].get("inspect"):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.9
+current_version = 5.1.10
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="5.1.9",
+    version="5.1.10",
     zip_safe=False,
 )


### PR DESCRIPTION
As @dbarbi mentioned today in our weekly meeting, `esm_runscripts` printing the MOTD twice is quite annoying. To prevent that a command line argument `--no-motd` can be provided. If you provide that when running `esm_runscripts` directly then no MOTD will be printed at all. If you don't then MOTD will be printed once but for the subsequent cases it will not be printed.

I think it is a good thing to have a flag to supress MOTD since it is annoying if you run `esm_master` or `esm_runscripts` many times.