### PR TITLE
hotfix/pbs prepend model stdout stderr

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.8"
+__version__ = "5.1.9"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/pbs.py
+++ b/esm_runscripts/pbs.py
@@ -188,7 +188,7 @@ class Pbs:
                 launcher_flags = self.calc_launcher_flags(config, model)
                 # Substitute @MODEL@ with the model name
                 launcher_flags = launcher_flags.replace("@MODEL@", model.upper())
-                component_lines.append(f'{launcher_flags} ./{command} ')
+                component_lines.append(f"{launcher_flags} ./{command} ")
 
         # Merge each component flags and commands into a single string
         components = sep.join(component_lines)

--- a/esm_runscripts/pbs.py
+++ b/esm_runscripts/pbs.py
@@ -170,6 +170,13 @@ class Pbs:
         #    self.calc_requirements_multi_aprun(config)
         #    return
 
+        # Calculates the left justification for the prepend of stdout and stderr
+        model_name_lengths = [
+            len(model) for model in config["general"]["valid_model_names"]
+            if "execution_command" in config[model] or "executable" in config[model]
+        ]
+        prep_just = max(model_name_lengths) + 3
+
         component_lines = []
         # Read in the separator to be used in between component calls in the job
         # launcher
@@ -182,11 +189,17 @@ class Pbs:
                 command = config[model]["execution_command"]
             elif "executable" in config[model]:
                 command = config[model]["executable"]
-            # Calculate launcher flags
+            # Prepare the MPMD commands
             if command:
                 launcher = config["computer"].get("launcher")
                 launcher_flags = self.calc_launcher_flags(config, model)
-                component_lines.append(f"{launcher_flags} ./{command} ")
+                # stdout and stderr modifications to prepend [MODEL] to each line
+                prep_str = f"[{model}]".upper().ljust(prep_just)
+                prep_model_std_oe = (
+                    f"1> >(sed 's/^/{prep_str}/' >&1) " +
+                    f"2> >(sed 's/^/{prep_str}/' >&2)"
+                )
+                component_lines.append(f'{launcher_flags} bash -c "./{command} {prep_model_std_oe}" ')
 
         # Merge each component flags and commands into a single string
         components = sep.join(component_lines)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.8
+current_version = 5.1.9
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="5.1.8",
+    version="5.1.9",
     zip_safe=False,
 )


### PR DESCRIPTION
In contrast with `srun`, `aprun` (Cray's parallel launcher) does not have a flag that allows for prepending the PE task to the stdout and stderr. This makes debugging of a coupled setup such as `AWICM3` more difficult, as it might not be clear where an error message might come from.

This hotfix prepends the corresponding `[<MODEL>]` to every stdout/stderr line when using PBS.

Before, the `aprun` call in the `.sad` file for `AWICM3` would look like:
```
time aprun -n 40 -N 40 -d 1 env OMP_NUM_THREADS=1 ./fesom \
         : -n 80 -N 40 -d 1 env OMP_NUM_THREADS=1 ./oifs -v ecmwf -e awi3 \
         : -n 1 -N 1 -d 1 env OMP_NUM_THREADS=1 ./rnfma  &
```
To prepend the `[<MODEL>]` the `aprun` call now looks like:
```
time aprun -n 40 -N 40 -d 1 env OMP_NUM_THREADS=1 bash -c "./fesom 1> >(sed 's/^/[FESOM]  /' >&1) 2> >(sed 's/^/[FESOM]  /' >&2)" \
         : -n 80 -N 40 -d 1 env OMP_NUM_THREADS=1 bash -c "./oifs -v ecmwf -e awi3 1> >(sed 's/^/[OIFS]   /' >&1) 2> >(sed 's/^/[OIFS]   /' >&2)" \
         : -n 1 -N 1 -d 1 env OMP_NUM_THREADS=1 bash -c "./rnfma 1> >(sed 's/^/[RNFMAP] /' >&1) 2> >(sed 's/^/[RNFMAP] /' >&2)"  &
```

As you can see we are substituting the call of the executable (i.e. `./fesom`) by `bash -c "./fesom <filtering commands for stdout/stderr>"`.

I find this not elegant at all but it works. Does anyone know if this change could have a negative impact in performance? Any suggestions for improvement?