### PR TITLE
fixed verbose in resolve_symlinks

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.12"
+__version__ = "5.1.13"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.13"
+__version__ = "5.1.14"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/database_actions.py
+++ b/esm_runscripts/database_actions.py
@@ -3,10 +3,11 @@ from datetime import datetime
 import sqlalchemy
 
 def database_entry(config):
-    if config["general"]["check"]:
-        database_entry_check(config)
-    elif config["general"]["jobtype"] == "compute":
-        database_entry_start(config)
+    if config.get("general", {}).get("use_database", True):
+        if config["general"]["check"]:
+            database_entry_check(config)
+        elif config["general"]["jobtype"] == "compute":
+            database_entry_start(config)
     return config
 
 def database_basic_entry(config):

--- a/esm_runscripts/filelists.py
+++ b/esm_runscripts/filelists.py
@@ -593,20 +593,20 @@ def check_for_unknown_files(config):
 
 
 
-def resolve_symlinks(file_source):
+def resolve_symlinks(file_source,verbose):
     if os.path.islink(file_source):
         points_to = os.path.realpath(file_source)
 
         # deniz: check if file links to itself. In UNIX
         # ln -s endless_link endless_link is a valid command
         if os.path.abspath(file_source) == points_to:
-            if config["general"]["verbose"]:
+            if verbose:
                 print(f"file {file_source} links to itself", flush=True)
                 print(datetime.datetime.now(), flush=True)
             return file_source
 
         # recursively find the file that the link is pointing to
-        return resolve_symlinks(points_to)
+        return resolve_symlinks(points_to,verbose)
     else:
         return(file_source)
 
@@ -656,7 +656,7 @@ def copy_files(config, filetypes, source, target):
                             print(datetime.datetime.now(), flush=True)
                         continue
                     dest_dir = os.path.dirname(file_target)
-                    file_source = resolve_symlinks(file_source)
+                    file_source = resolve_symlinks(file_source,config["general"]["verbose"])
                     if not os.path.isdir(file_source):
                         try:
                             if not os.path.isdir(dest_dir):

--- a/esm_runscripts/tidy.py
+++ b/esm_runscripts/tidy.py
@@ -681,12 +681,12 @@ def copy_all_results_to_exp(config):
                         + destination
                     )
             else:
-                linkdest = resolve_symlinks(source)
+                linkdest = resolve_symlinks(source,config["general"]["verbose"])
                 #newlinkdest = (
                 #    destination.rsplit("/", 1)[0] + "/" + linkdest.rsplit("/", 1)[-1]
                 #)
                 if os.path.islink(destination):
-                    destdest = resolve_symlinks(source)
+                    destdest = resolve_symlinks(source,config["general"]["verbose"])
                     if linkdest == destdest:
                         # both links are identical, skip
                         continue

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.12
+current_version = 5.1.13
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.13
+current_version = 5.1.14
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="5.1.12",
+    version="5.1.13",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="5.1.13",
+    version="5.1.14",
     zip_safe=False,
 )


### PR DESCRIPTION
`config["general"]["verbose"]` is not available in `resolve_symlinks` as `config` is not passed to `resolve_symlinks`. I think I was the first hitting this error when using linking to excessively.