### PR TITLE
fix(database_actions): allows user to opt-out of using the database

### DIFF
--- a/esm_runscripts/database_actions.py
+++ b/esm_runscripts/database_actions.py
@@ -3,10 +3,11 @@ from datetime import datetime
 import sqlalchemy
 
 def database_entry(config):
-    if config["general"]["check"]:
-        database_entry_check(config)
-    elif config["general"]["jobtype"] == "compute":
-        database_entry_start(config)
+    if config.get("general", {}).get("use_database", True):
+        if config["general"]["check"]:
+            database_entry_check(config)
+        elif config["general"]["jobtype"] == "compute":
+            database_entry_start(config)
     return config
 
 def database_basic_entry(config):


### PR DESCRIPTION
…See Issue https://github.com/esm-tools/esm_tools/issues/355)

This allows the user to opt-out of the database actions by setting `general.use_database` to False in their runscript. Currently the default is True