### PR TITLE
added ability to read export_mode from coupling directions block

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.15"
+__version__ = "5.1.16"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/coupler.py
+++ b/esm_runscripts/coupler.py
@@ -255,20 +255,23 @@ class coupler_class:
                                 if not found_left or not found_right:
                                     sys.exit(0)
 
-                            direction_info = None
-                            if "coupling_directions" in full_config[self.name]:
-                                if right_grid + "->" + left_grid in full_config[self.name]["coupling_directions"]:
-                                    direction_info = full_config[self.name]["coupling_directions"][right_grid + "->" + left_grid]
-                            transf_info = None
-                            if "coupling_methods" in full_config[self.name]:
-                                if interpolation in full_config[self.name]["coupling_methods"]:
-                                    transf_info = full_config[self.name]["coupling_methods"][interpolation]
-
                             if "export_mode" in full_config[self.name]:
                                 export_mode = full_config[self.name]["export_mode"]
                             else:
                                 export_mode = "DEFAULT"
-                            # print("DEBUG: EXPORT_MODE: ",export_mode)
+                            
+                            # Use export_mode from coupling_directions if set. Required for NEMO-AGRIF
+                            direction_info = None
+                            if "coupling_directions" in full_config[self.name]:
+                                if right_grid + "->" + left_grid in full_config[self.name]["coupling_directions"]:
+                                    direction_info = full_config[self.name]["coupling_directions"][right_grid + "->" + left_grid]
+                                    export_mode = direction_info.get("export_mode",export_mode)
+
+                            transf_info = None
+                            if "coupling_methods" in full_config[self.name]:
+                                if interpolation in full_config[self.name]["coupling_methods"]:
+                                    transf_info = full_config[self.name]["coupling_methods"][interpolation]
+                            
                             self.coupler.add_coupling(lefts, lgrid_info, rights, rgrid_info, direction_info, transf_info, restart_file, full_config[self.name]["coupling_time_step"], full_config[self.name]["lresume"], export_mode=export_mode)
 
             if "coupling_input_fields" in full_config[self.name]:

--- a/esm_runscripts/coupler.py
+++ b/esm_runscripts/coupler.py
@@ -255,11 +255,8 @@ class coupler_class:
                                 if not found_left or not found_right:
                                     sys.exit(0)
 
-                            if "export_mode" in full_config[self.name]:
-                                export_mode = full_config[self.name]["export_mode"]
-                            else:
-                                export_mode = "DEFAULT"
-                            
+                            export_mode = full_config[self.name].get("export_mode", "DEFAULT")
+
                             # Use export_mode from coupling_directions if set. Required for NEMO-AGRIF
                             direction_info = None
                             if "coupling_directions" in full_config[self.name]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.15
+current_version = 5.1.16
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dbarbi/esm_runscripts',
-    version="5.1.15",
+    version="5.1.16",
     zip_safe=False,
 )


### PR DESCRIPTION
could this be merged soon, it's required for our new people to run NEMO with high resolution nest (NEMO-AGRIF) within ESM-Tools