### PR TITLE
solves a problem with the check of FESOM paths from the namelist

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.17"
+__version__ = "5.1.18"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/filelists.py
+++ b/esm_runscripts/filelists.py
@@ -705,8 +705,8 @@ def copy_files(config, filetypes, source, target):
 
 def report_missing_files(config):
     # this list is populated by the ``copy_files`` function in filelists.py
+    config = _check_fesom_missing_files(config)
     if "files_missing_when_preparing_run" in config["general"]:
-        config = _check_fesom_missing_files(config)
         if not config["general"]["files_missing_when_preparing_run"] == {}:
             print("MISSING FILES:", flush=True)
         for missing_file in config["general"]["files_missing_when_preparing_run"]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.17
+current_version = 5.1.18
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/esm-tools/esm_runscripts',
-    version="5.1.17",
+    version="5.1.18",
     zip_safe=False,
 )


### PR DESCRIPTION
The method for checking if there were missing paths in the `namelist.config` from FESOM was run only if `files_missing_when_preparing_run` exists (i.e. if there were already other missing files defined through the standard "filedictionary" way). This fix makes both checks independent, so if the missing files belong only to the `namelist.config` they are still reported.