### PR TITLE
fix/proc and core calc

### DIFF
--- a/esm_runscripts/batch_system.py
+++ b/esm_runscripts/batch_system.py
@@ -196,28 +196,31 @@ class batch_system:
         if cluster in reserved_jobtypes:
             for model in config["general"]["valid_model_names"]:
                 omp_num_threads = int(config[model].get("omp_num_threads", 1))
-                if "nproca" in config[model] and "nprocb" in config[model]:
-                    config[model]["tasks"] = config[model]["nproca"] * config[model]["nprocb"]
+                # KH 30.04.20: nprocrad is replaced by more flexible
+                # partitioning using nprocar and nprocbr
+                no_nprocr = ["remove_from_namelist", 0]
+                if (
+                    config[model].get("nprocar", no_nprocr[0]) not in no_nprocr
+                    and
+                    config[model].get("nprocbr", no_nprocr[0]) not in no_nprocr
+                ):
+                    config[model]["tasks"] = \
+                        config[model]["nprocar"] * config[model]["nprocbr"]
+
+                elif "nproca" in config[model] and "nprocb" in config[model]:
+                    config[model]["tasks"] = \
+                        config[model]["nproca"] * config[model]["nprocb"]
                     #end_proc = start_proc + int(config[model]["nproca"])*int(config[model]["nprocb"]) - 1
-                    if (
-                        config[model].get("nprocar", "remove_from_namelist") not in ["remove_from_namelist", 0]
-                        and
-                        config[model].get("nprocbr", "remove_from_namelist") not in ["remove_from_namelist", 0]
-                        ):
-                            config[model]["tasks"] = config[model]["nprocar"] * config[model]["nprocbr"]
-                
+
                 elif "nproc" in config[model]:
                     print(f"nproc: {config[model]['nproc']}")
                     config[model]["tasks"] = config[model]["nproc"]
 
                     #cores_per_node = config['computer']['cores_per_node']
-                    # If heterogeneous MPI-OMP
-                # KH 30.04.20: nprocrad is replaced by more flexible
-                # partitioning using nprocar and nprocbr
                 else:
                         continue
 
-                    
+
                 nproc = config[model]["tasks"]
                 if cluster == "compute":
                     cores_per_node = config['computer']['partitions']['compute']['cores_per_node']

--- a/esm_runscripts/batch_system.py
+++ b/esm_runscripts/batch_system.py
@@ -196,21 +196,21 @@ class batch_system:
         if cluster in reserved_jobtypes:
             for model in config["general"]["valid_model_names"]:
                 omp_num_threads = int(config[model].get("omp_num_threads", 1))
-                # KH 30.04.20: nprocrad is replaced by more flexible
-                # partitioning using nprocar and nprocbr
-                no_nprocr = ["remove_from_namelist", 0]
-                if (
-                    config[model].get("nprocar", no_nprocr[0]) not in no_nprocr
-                    and
-                    config[model].get("nprocbr", no_nprocr[0]) not in no_nprocr
-                ):
-                    config[model]["tasks"] = \
-                        config[model]["nprocar"] * config[model]["nprocbr"]
 
-                elif "nproca" in config[model] and "nprocb" in config[model]:
+                if "nproca" in config[model] and "nprocb" in config[model]:
                     config[model]["tasks"] = \
                         config[model]["nproca"] * config[model]["nprocb"]
                     #end_proc = start_proc + int(config[model]["nproca"])*int(config[model]["nprocb"]) - 1
+                    # KH 30.04.20: nprocrad is replaced by more flexible
+                    # partitioning using nprocar and nprocbr
+                    no_nprocr = ["remove_from_namelist", 0]
+                    if (
+                        config[model].get("nprocar", no_nprocr[0]) not in no_nprocr
+                        and
+                        config[model].get("nprocbr", no_nprocr[0]) not in no_nprocr
+                    ):
+                        config[model]["tasks"] += \
+                            config[model]["nprocar"] * config[model]["nprocbr"]
 
                 elif "nproc" in config[model]:
                     print(f"nproc: {config[model]['nproc']}")

--- a/esm_runscripts/batch_system.py
+++ b/esm_runscripts/batch_system.py
@@ -203,11 +203,11 @@ class batch_system:
                     #end_proc = start_proc + int(config[model]["nproca"])*int(config[model]["nprocb"]) - 1
                     # KH 30.04.20: nprocrad is replaced by more flexible
                     # partitioning using nprocar and nprocbr
-                    no_nprocr = ["remove_from_namelist", 0]
+                    remove_nprocr_options = ["remove_from_namelist", 0]
                     if (
-                        config[model].get("nprocar", no_nprocr[0]) not in no_nprocr
+                        config[model].get("nprocar", 0) not in remove_nprocr_options
                         and
-                        config[model].get("nprocbr", no_nprocr[0]) not in no_nprocr
+                        config[model].get("nprocbr", 0) not in remove_nprocr_options
                     ):
                         config[model]["tasks"] += \
                             config[model]["nprocar"] * config[model]["nprocbr"]


### PR DESCRIPTION
EDIT: Some of the questions I had I have solved by now. **Question b** is the one keeping me away from merging into `prep_release`.

This is the first fix to `prep_release` branch, branched off from `preppreprelease`.

It consist of two different modifications:

1. `end_proc` and `end_core` were not updated when used to reset `start_proc` and `start_core` and therefore the hostfile for AWICM2 would look like:
    ```
    0-575 ./echam6
    1-288 ./fesom
    ```
    
2. This one is less clear to me and I need information from @dbarbi , @pgierz and/or @khimstedt . In `release` the `nprocar`/`nprocbr` lines are inside the `if` for `nproca`/`nprocb`:
    https://github.com/esm-tools/esm_runscripts/blob/b3a115d013cb3c553d0464527d869d0b316bf386/esm_runscripts/batch_system.py#L146-L156
    This fix makes the `if` of `nprocar`/`nprocbr` to only be evaluated if `nproca` and `nprocb` are defined (as it is the case in `release`), but in `prep_release` was made to be independent (see the diffs in the file).
I decided to come back to the `release` strategy because for my current test `nprocar` and `nprocbr` would be `0`, turning my `start_proc` to `-1`.

My questions are as follow:
    a. Should `nprocar`/`nprocbr` be independent of `nproca`/`nprocb` at the time of calculating the number of tasks/cores or should we on the contrary only check for `nprocar` if we already have an `nproca` defined?
    b. When we check the `nprocar`/`nprocbr` values, should we also check for 0 values as in the following line, or checking only for `remove_from_namelist` is okay?
    https://github.com/esm-tools/esm_runscripts/blob/326448e7e340ba8c375fdbf29cee1440b0777bf4/esm_runscripts/batch_system.py#L203
