### PR TITLE
Hotfix/better yaml dumper

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.24"
+__version__ = "5.1.25"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/compute.py
+++ b/esm_runscripts/compute.py
@@ -309,7 +309,11 @@ def initialize_experiment_logfile(config):
 
 
 def _write_finalized_config(config):
-    """Writes <expid>_finished_config.yaml file"""
+    """Writes <expid>_finished_config.yaml file
+    Parameters
+    ----------
+    config : esm-tools config object
+    """
     # first define the representers for the non-built-in types, as recommended
     # here: https://pyyaml.org/wiki/PyYAMLDocumentation
     def date_representer(dumper, date):
@@ -317,7 +321,7 @@ def _write_finalized_config(config):
         
     def calendar_representer(dumper, calendar):
         # Calendar has a __str__ method
-        return dumper.represent_str(calendar.__str__())
+        return dumper.represent_str(str(calendar))
 
     def batch_system_representer(dumper, batch_system):
         return dumper.represent_str(f"{batch_system.name}")
@@ -365,7 +369,8 @@ def _write_finalized_config(config):
         config_final = copy.deepcopy(config) #PrevRunInfo
         del config_final["prev_run"]         #PrevRunInfo
 
-        out = yaml.dump(config_final, Dumper=EsmConfigDumper, width=10000)   #PrevRunInfo
+        out = yaml.dump(config_final, Dumper=EsmConfigDumper, width=10000, 
+            indent=4)   #PrevRunInfo
         config_file.write(out)
     return config
     

--- a/esm_runscripts/compute.py
+++ b/esm_runscripts/compute.py
@@ -4,13 +4,15 @@ import subprocess
 import copy
 import pathlib
 
-import esm_rcfile
 import six
 import yaml
-from esm_calendar import Date
 from colorama import Fore, Back, Style, init
 
 import esm_tools
+import esm_calendar
+import esm_parser
+import esm_rcfile
+import esm_runscripts
 
 from .batch_system import batch_system
 from .filelists import copy_files, log_used_files
@@ -307,24 +309,53 @@ def initialize_experiment_logfile(config):
 
 
 def _write_finalized_config(config):
+    # first define the representers for the non-built-in types, as recommended
+    # here: https://pyyaml.org/wiki/PyYAMLDocumentation
     def date_representer(dumper, date):
-        return dumper.represent_str("%s" % date.output())
+        return dumper.represent_str(f"{date.output()}")
+        
+    def calendar_representer(dumper, calendar):
+        # Calendar has a __str__ method
+        return dumper.represent_str(calendar.__str__())
 
     def batch_system_representer(dumper, batch_system):
         return dumper.represent_str(f"{batch_system.name}")
 
-    def strip_python_tags(s):
-        result = []
-        for line in s.splitlines():
-            idx = line.find("!!python/")
-            if idx > -1:
-                line = line[:idx]
-            result.append(line)
-        return '\n'.join(result)
+    def coupler_representer(dumper, coupler):
+        # prevent dumping of whole namcouple
+        return dumper.represent_str(f"{coupler.name}")
 
-    yaml.add_representer(Date, date_representer)
-    yaml.add_representer(batch_system, batch_system_representer)
+    def oasis_representer(dumper, oasis):
+        return dumper.represent_str(f"{oasis.name}")
 
+    # dumper object for the ESM-Tools configuration
+    class EsmConfigDumper(yaml.dumper.Dumper):
+        pass
+
+    # pyyaml does not support tuple and prints !!python/tuple
+    EsmConfigDumper.add_representer(tuple, yaml.representer.SafeRepresenter.represent_list) 
+
+    # Determine how non-built-in types will be printed be the YAML dumper
+    EsmConfigDumper.add_representer(esm_calendar.Date, date_representer) 
+    
+    EsmConfigDumper.add_representer(esm_calendar.esm_calendar.Calendar, 
+        calendar_representer) 
+        # yaml.representer.SafeRepresenter.represent_str) 
+        
+    EsmConfigDumper.add_representer(esm_parser.esm_parser.ConfigSetup, 
+        yaml.representer.SafeRepresenter.represent_dict) 
+        
+    EsmConfigDumper.add_representer(batch_system, batch_system_representer)
+
+    # format for the other ESM data structures
+    EsmConfigDumper.add_representer(esm_rcfile.esm_rcfile.EsmToolsDir, 
+        yaml.representer.SafeRepresenter.represent_str) 
+        
+    EsmConfigDumper.add_representer(esm_runscripts.coupler.coupler_class, 
+        coupler_representer) 
+        
+    EsmConfigDumper.add_representer(esm_runscripts.oasis.oasis, oasis_representer) 
+    
     config_file_path = \
         f"{config['general']['thisrun_config_dir']}"\
         f"/{config['general']['expid']}_finished_config.yaml"
@@ -332,10 +363,11 @@ def _write_finalized_config(config):
         # Avoid saving ``prev_run`` information in the config file
         config_final = copy.deepcopy(config) #PrevRunInfo
         del config_final["prev_run"]         #PrevRunInfo
-        out = yaml.dump(config_final)        #PrevRunInfo
-        out = strip_python_tags(out)
+
+        out = yaml.dump(config_final, Dumper=EsmConfigDumper, width=10000)   #PrevRunInfo
         config_file.write(out)
     return config
+    
 
 def color_diff(diff):
     for line in diff:

--- a/esm_runscripts/compute.py
+++ b/esm_runscripts/compute.py
@@ -309,6 +309,7 @@ def initialize_experiment_logfile(config):
 
 
 def _write_finalized_config(config):
+    """Writes <expid>_finished_config.yaml file"""
     # first define the representers for the non-built-in types, as recommended
     # here: https://pyyaml.org/wiki/PyYAMLDocumentation
     def date_representer(dumper, date):

--- a/esm_runscripts/prev_run.py
+++ b/esm_runscripts/prev_run.py
@@ -226,7 +226,9 @@ class PrevRunInfo(dict):
                 # Open the file and load the previous run information
                 with open(prev_run_config_file, "r") as prev_file:
                     prev_config = yaml.load(prev_file, Loader=yaml.FullLoader)
-                prev_config = prev_config["dictitems"]
+                # Back-compatibility with old config files
+                if "dictitems" in prev_config:
+                    prev_config = prev_config["dictitems"]
                 # In case a ``prev_run`` info exists inside the file, remove it to
                 # avoid config files from getting huge (prev_run nested inside
                 # prev_run...)

--- a/esm_runscripts/prev_run.py
+++ b/esm_runscripts/prev_run.py
@@ -368,6 +368,11 @@ class PrevRunInfo(dict):
                 # There is no need of prev_run for cold starts. Do nothing
                 return prev_run_config_file, ""
 
+        # Resolve config path
+        config_dir = esm_parser.find_variable(
+            ["general"], config_dir, self._config, [], True
+        )
+
         # Check for errors
         if not os.path.isdir(config_dir):
             esm_parser.user_error("Config folder not existing", (

--- a/esm_runscripts/sim_objects.py
+++ b/esm_runscripts/sim_objects.py
@@ -401,7 +401,7 @@ class PrevRunInfo(dict):
             if os.path.isfile(prev_run_config_file):
                 with open(prev_run_config_file, "r") as prev_file:
                     prev_config = yaml.load(prev_file, Loader=yaml.FullLoader)
-                self._prev_config = prev_config["dictitems"]
+                self._prev_config = prev_config
                 # In case a ``prev_run`` info exists inside the file, remove it to
                 # avoid config files from getting huge (prev_run nested inside
                 # prev_run...)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.24
+current_version = 5.1.25
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/esm-tools/esm_runscripts',
-    version="5.1.24",
+    version="5.1.25",
     zip_safe=False,
 )


### PR DESCRIPTION
- Removed the topmost key `dictitem`, which is placed by `pyyaml` module. Thanks to the supreme documentation, it took few hours to figure out how to get it out. 
- Now there is no need to things like `config = read_config_file['dictitems']`
- No break up of long string on to multiple lines. Check any finished_config.yaml file. Many strings are broken into multiple lines although they are not in the incoming YAML files
- removed `strip_python_tags()` function and replaced it with added support to esm-tools data types, such as
    - `EsmToolsDir`
    - `Calendar`
    - ...
- Added support for `tuple`, which is missing in the original `pyyaml`
- By adding support for some data types, eg. `coupler_class`, the output is much cleaner. Eg. it does not dump the complete `namcouple` file. 
- The output is exactly the same apart from improved parts. Use `vimdiff` with `set diffopt+=iwhite` to compare
- Provides a good starting point for implementing support for other data types, in case they need to enter the `finished_config.yaml` file and need better formatting.
