### PR TITLE
replaced inside flag with deep nesting

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.22"
+__version__ = "5.1.23"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/compute.py
+++ b/esm_runscripts/compute.py
@@ -471,6 +471,8 @@ def copy_tools_to_thisrun(config):
     fromdir = os.path.realpath(gconfig["started_from"])
     # Directory where the runscript is copied to
     scriptsdir = os.path.realpath(gconfig["experiment_scripts_dir"])
+    # basedir + expid
+    expdir = os.path.realpath(gconfig['experiment_dir'])
 
     # Paths inside the experiment directory where esm_tools and namelists
     # are copied to. Those are not functional but a reference to what was
@@ -505,16 +507,24 @@ def copy_tools_to_thisrun(config):
 
     # check for recursive creation of the file tree. This prevents the risk of
     # creating a run directory tree inside the `scriptsdir`
-    scriptsdir_inside_fromdir = pathlib.Path(fromdir) in pathlib.Path(scriptsdir).parents
-    if scriptsdir_inside_fromdir and config["general"]["verbose"]:
+    # example:
+    # fromdir:    /mnt/lustre02/work/project/username/basedir
+    # scriptsdir: /mnt/lustre02/work/project/username/basedir/expid/scripts
+    # it is assumed that if 5th parent of the scriptsdir is inside the fromdir
+    # then probably some sort of infinite recursion is entered. These lines
+    # protect such problems
+    scriptsdir_deep_parents = list(pathlib.Path(scriptsdir).parents)[5:]
+    deep_nesting_found = pathlib.Path(expdir) in scriptsdir_deep_parents
+    if deep_nesting_found and config["general"]["verbose"]:
         print("WARNING: scriptsdir is inside fromdir")
-        print(f"  - scriptsdir: {scriptsdir}")
-        print(f"  - fromdir:    {fromdir}")
+        print(f"  - scriptsdir:         {scriptsdir}")
+        print(f"  - fromdir:            {fromdir}")
+        print(f"  - experiment dir:     {expdir}")
     
     # If ``fromdir`` and ``scriptsdir`` are the same, this is already a computing
     # simulation which means we want to use the script in the experiment folder,
     # so no copying is needed
-    if (fromdir == scriptsdir) or scriptsdir_inside_fromdir and not gconfig["update"]:
+    if (fromdir == scriptsdir) or deep_nesting_found and not gconfig["update"]:
         if config["general"]["verbose"]:
             print("Started from the experiment folder, continuing...")
         return config

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.22
+current_version = 5.1.23
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/esm-tools/esm_runscripts',
-    version="5.1.22",
+    version="5.1.23",
     zip_safe=False,
 )


### PR DESCRIPTION
This solves the issue https://github.com/esm-tools/esm_runscripts/issues/156

I was able to replicate the issue that @mandresm reported. It turns out to be that if the runscript is inside the workdir (where model also runs) and `--update` is on the anti-recursion guard is activated (friendly fire). That guard needs to be there but we clearly need a solution.

`scriptsdir_inside_fromdir` is replaced by `deep_nesting_found`. It basically goes 6 directories up and checks if the `scriptsdir` is inside that directory and its parents. If some kind of infinite recursion occurs (should not occur but prepare for the worst), it will not proceed infinitely. Those infinite recursion was encountered in some experimental runs from Paul, and probably due to the newly implemented `!ENV` feature at that time.

I checked the following cases:
- release branch, no update, workdir
  - **result:** no YAML runscript (or secondary script, eg. `further_reading`) in the `expid/scripts` directory.

- bugfix branch, no update, workdir
  - **result:** the missing files are there 

**Comparison:**
- Enter each `expid` and 
```bash
find . &> ../file_list_release
find . &> ../file_list_bugfix
```
- Then vimdiff: `vimdiff file_list_release file_list_bugfix`

The only differences were the YAML files in the `expid/scripts` directory