### PR TITLE
bugfix that takes mixed cases into account

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.23"
+__version__ = "5.1.24"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/namelists.py
+++ b/esm_runscripts/namelists.py
@@ -126,7 +126,33 @@ class Namelist:
                     value = change_entries[key]
                     if value == "remove_from_namelist":
                         namelist_removes.append((namelist, change_chapter, key))
+
+                        # the key is probably coming from esm_tools config
+                        # files or from a user runscript. It can contain lower
+                        # case, but the original Fortran namelist could be in
+                        # any case combination. Here `original_key` is coming
+                        # from the default namelist and may contain mixed case.
+                        # `key` is the processed variable my f90nml package and
+                        # is lowercase
+                        remove_original_key = False
+
+                        # traverse the namelist chapter and see if a mixed case
+                        # variable is also found
+                        for key2 in namelist_changes[namelist][change_chapter]:
+                            # take care of the MiXeD FORTRAN CaSeS
+                            if key2.lower() == key.lower() and key2 != key:
+                                original_key = key2
+                                remove_original_key = True
+                                namelist_removes.append((namelist, change_chapter, original_key))
+
+                        # remove both lowercase and mixed case variables
                         del namelist_changes[namelist][change_chapter][key]
+                        if remove_original_key:
+                            del namelist_changes[namelist][change_chapter][original_key]
+                            
+                        # mconfig instead of config, Grrrrr
+                        print(f"- NOTE: removing the variable: {key} from the namelist: {namelist}")
+
         for remove in namelist_removes:
             namelist, change_chapter, key = remove
             logging.debug("Removing from %s: %s, %s", namelist, change_chapter, key)

--- a/esm_runscripts/namelists.py
+++ b/esm_runscripts/namelists.py
@@ -132,8 +132,8 @@ class Namelist:
                         # case, but the original Fortran namelist could be in
                         # any case combination. Here `original_key` is coming
                         # from the default namelist and may contain mixed case.
-                        # `key` is the processed variable my f90nml package and
-                        # is lowercase
+                        # `key` is the processed variable from f90nml module and
+                        # is lowercase.
                         remove_original_key = False
 
                         # traverse the namelist chapter and see if a mixed case

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.23
+current_version = 5.1.24
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/esm-tools/esm_runscripts',
-    version="5.1.23",
+    version="5.1.24",
     zip_safe=False,
 )


### PR DESCRIPTION
**TLDR:** This bug fix solves the issue when there is a case mismatch between the Fortran namelists. Remember that Fortran is CaSe InSeNsiTiVe. 

Look at this example: 
The default Fesom 2 namelist that we ship contains:

https://github.com/esm-tools/esm_tools/blob/2d61dd4a48cf5b3306320ade243cdae0b4748b42/namelists/fesom2/namelist.config#L19-L26
```fortran
&paths
MeshPath=<meshpath>
OpbndPath=''
ClimateDataPath=<climatedatapath>
ForcingDataPath=<forcingdatapath>
TideForcingPath=<tideforcingpath>
ResultPath=<resultpath>
/
```

When the user runs the simplest runscript that we ship. This error is printed:

```
MISSING FILES:

- missing source: somepath
- missing target: opbndpath (from namelist.config in FESOM)
2021-07-21 12:23:42.899989

- missing source: somepath
- missing target: tideforcingpath (from namelist.config in FESOM)
2021-07-21 12:23:42.900060
```

An easy solution is addind `remove_from_namelist` in the runscript, such as:

```yaml
fesom:
    namelist_changes:
        namelist.config:
            paths:
                opbndpath: "remove_from_namelist"
                tideforcingpath: "remove_from_namelist"
```

This does not work because `f90nml` converts everything to lower case (I find this good, at least consistent). If we add a breakpoint into the `namelists.py`, we can see that

```python
(Pdb) pp change_entries
{'ClimateDataPath': '/work/ollie/pool/FESOM//hydrography/',
 'ForcingDataPath': '/work/ollie/pool/FESOM//forcing/',
 'MeshPath': '/work/ollie/pool/FESOM/fesom2.0/meshes/mesh_CORE2_final/',
 'OpbndPath': 'somepath',
 'ResultPath': '/work/ollie/dural/claudia//my_first_test1//run_20010101-20011231/work/',
 'TideForcingPath': 'somepath',
 'opbndpath': 'remove_from_namelist',
 'tideforcingpath': 'remove_from_namelist'}
```

So, `remove_from_namelist` will remove `opbndpath` and `tideforcingpath` but not `OpbndPath` or `TideForcingPath`. We need to convert everything to the same case (eg. lowercase) and then perform a check if a mixed case version also exists.

Also note that, I don't like passing `mconfig` or `gconfig` to the functions. The whole configuration should be passed. It is always possible to write `gconfig = config['general']` but recovering the top-level configuration is not possible from the child config. For this reason I can't use if `config['verbose']` here. I have to change all of the function calls.