### PR TITLE
possibility to define file movements specific to each file

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.26"
+__version__ = "5.1.27"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.25"
+__version__ = "5.1.26"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/compute.py
+++ b/esm_runscripts/compute.py
@@ -302,7 +302,7 @@ def initialize_experiment_logfile(config):
             f"{config['general']['experiment_dir']}/log" \
             f"/{config['general']['expid']}_esm_runscripts_" \
             f"{config['general']['run_datestamp']}.log"
-        
+
         logger.trace_sink.def_path(logfile_path)
 
     return config
@@ -318,7 +318,7 @@ def _write_finalized_config(config):
     # here: https://pyyaml.org/wiki/PyYAMLDocumentation
     def date_representer(dumper, date):
         return dumper.represent_str(f"{date.output()}")
-        
+
     def calendar_representer(dumper, calendar):
         # Calendar has a __str__ method
         return dumper.represent_str(str(calendar))
@@ -338,29 +338,30 @@ def _write_finalized_config(config):
         pass
 
     # pyyaml does not support tuple and prints !!python/tuple
-    EsmConfigDumper.add_representer(tuple, yaml.representer.SafeRepresenter.represent_list) 
+    EsmConfigDumper.add_representer(tuple, yaml.representer.SafeRepresenter.represent_list)
 
     # Determine how non-built-in types will be printed be the YAML dumper
-    EsmConfigDumper.add_representer(esm_calendar.Date, date_representer) 
-    
-    EsmConfigDumper.add_representer(esm_calendar.esm_calendar.Calendar, 
-        calendar_representer) 
-        # yaml.representer.SafeRepresenter.represent_str) 
-        
-    EsmConfigDumper.add_representer(esm_parser.esm_parser.ConfigSetup, 
-        yaml.representer.SafeRepresenter.represent_dict) 
-        
+    EsmConfigDumper.add_representer(esm_calendar.Date, date_representer)
+
+    EsmConfigDumper.add_representer(esm_calendar.esm_calendar.Calendar,
+        calendar_representer)
+        # yaml.representer.SafeRepresenter.represent_str)
+
+    EsmConfigDumper.add_representer(esm_parser.esm_parser.ConfigSetup,
+        yaml.representer.SafeRepresenter.represent_dict)
+
     EsmConfigDumper.add_representer(batch_system, batch_system_representer)
 
     # format for the other ESM data structures
-    EsmConfigDumper.add_representer(esm_rcfile.esm_rcfile.EsmToolsDir, 
-        yaml.representer.SafeRepresenter.represent_str) 
-        
-    EsmConfigDumper.add_representer(esm_runscripts.coupler.coupler_class, 
-        coupler_representer) 
-        
-    EsmConfigDumper.add_representer(esm_runscripts.oasis.oasis, oasis_representer) 
-    
+    EsmConfigDumper.add_representer(esm_rcfile.esm_rcfile.EsmToolsDir,
+        yaml.representer.SafeRepresenter.represent_str)
+
+    EsmConfigDumper.add_representer(esm_runscripts.coupler.coupler_class,
+        coupler_representer)
+
+    if "oasis3mct" in config:
+        EsmConfigDumper.add_representer(esm_runscripts.oasis.oasis, oasis_representer)
+
     config_file_path = \
         f"{config['general']['thisrun_config_dir']}"\
         f"/{config['general']['expid']}_finished_config.yaml"
@@ -369,11 +370,11 @@ def _write_finalized_config(config):
         config_final = copy.deepcopy(config) #PrevRunInfo
         del config_final["prev_run"]         #PrevRunInfo
 
-        out = yaml.dump(config_final, Dumper=EsmConfigDumper, width=10000, 
+        out = yaml.dump(config_final, Dumper=EsmConfigDumper, width=10000,
             indent=4)   #PrevRunInfo
         config_file.write(out)
     return config
-    
+
 
 def color_diff(diff):
     for line in diff:

--- a/esm_runscripts/filelists.py
+++ b/esm_runscripts/filelists.py
@@ -803,6 +803,40 @@ def complete_all_file_movements(config):
                             config = complete_one_file_movement(config, model, filetype, movement, movement_type)
                         del mconfig["file_movements"][filetype]["all_directions"]
 
+            # Complete file specific movements with ``all_directions``
+            for file_in_fm in mconfig["file_movements"]:
+                # If it is a specific file, and not a file type
+                if file_in_fm not in (
+                    config["general"]["all_model_filetypes"]
+                    + ["scripts", "unknown"]
+                ):
+                    # Check syntax for restart files
+                    if (
+                        file_in_fm in mconfig.get("restart_in_files", {})
+                        or file_in_fm in mconfig.get("restart_out_files", {})
+                    ):
+                        esm_parser.user_error(
+                            "Movement direction not specified",
+                            f"'{model}.file_movements.{file_in_fm}' refers to a "
+                            + "restart file which can be moved/copied/link in two "
+                            + "directions, into the 'work' folder and out of the "
+                            + "'work' folder. Please, add the direction '_in' or "
+                            + f"'_out' to '{file_in_fm}':\n\n{model}:\n    "
+                            + f"file_movements:\n        {file_in_fm}_<in/out>:\n"
+                            + f"            [ ... ]"
+                        )
+                    # Solve ``all_directions``
+                    file_spec_movements = mconfig["file_movements"][file_in_fm]
+                    if "all_directions" in file_spec_movements:
+                        movement_type = file_spec_movements["all_directions"]
+                        for movement in [
+                            'init_to_exp', 'exp_to_run', 'run_to_work', 'work_to_run'
+                        ]:
+                            config = complete_one_file_movement(
+                                config, model, file_in_fm, movement, movement_type
+                            )
+                        del mconfig["file_movements"][file_in_fm]["all_directions"]
+
             if "default" in mconfig["file_movements"]:
                 if "all_directions" in mconfig["file_movements"]["default"]:
                     movement_type = mconfig["file_movements"]["default"]["all_directions"]
@@ -823,22 +857,13 @@ def get_movement(config, model, categ, filetype, source, target):
     if isinstance(categ, str):
         categ = categ.split("_glob_")[0]
     # Two type of directions are needed for restarts, therefore, the categories need an
-    # "_in" or "_out" at the end. They should be defined like that also in the
-    # ``file_movements`` if specific files are treated differently, in a similar way
-    # in which ``restart_in`` and ``restart_out`` need their own ``file_movements``.
+    # "_in" or "_out" at the end.
     if filetype=="restart_in":
         categ = f"{categ}_in"
     elif filetype=="restart_out":
         categ = f"{categ}_out"
-        # Check for endings TODO
-    # Get file specific movements and complete with ``all_directions``
+    # File specific movements
     file_spec_movements = config[model]["file_movements"].get(categ, {})
-    if "all_directions" in file_spec_movements:
-        movement_type = file_spec_movements["all_directions"]
-        for movement in ['init_to_exp', 'exp_to_run', 'run_to_work', 'work_to_run']:
-            config = complete_one_file_movement(config, model, categ, movement, movement_type)
-        del config[model]["file_movements"][categ]["all_directions"]
-
     # Movements associated to ``filetypes``
     file_type_movements = config[model]["file_movements"][filetype]
     if source == "init":

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.25
+current_version = 5.1.26
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.26
+current_version = 5.1.27
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/esm-tools/esm_runscripts',
-    version="5.1.25",
+    version="5.1.26",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/esm-tools/esm_runscripts',
-    version="5.1.26",
+    version="5.1.27",
     zip_safe=False,
 )


### PR DESCRIPTION
This feature allows to control file movements for specific files. For example, new versions of fesom in the future will include the normal restart files, but also memory dumps (for fast writing and restarting with large simulations). While the regular restart files is desirable to treat them with the standard copying, the memory dumps (as they are a lot of files) is probably best to move them around. An extra layer of control is added so that it is possible to add in the `fesom-2.x.yaml`:
```
file_movements:
        fesom_raw_restart_in:
                all_directions: move
        fesom_raw_restart_out:
                all_directions: move
```
where `fesom_raw_restart` is the key defined in `restart_in_files` and `restart_out_files` for the fesom memory dumps, and the additional `_in` and `_out` after `fesom_raw_restart` stand for the direction (only for restart files, for output for example the extra `_in` and `_out` is not needed).

Once again, this is a feature that will be needed very soon in AWICM3 and that's why I am asking to merge into release as a patch. I promise, I'll stop doing this, I know is not very sustainable...

It is ready to be reviewed though I still have a list of things I want to do before merging.

**To do**

- [x] Normal restart tests
- [x] Branching off tests
- [x] FESOM2 test
- [x] AWICM test
- [x] AWICM2 test
- [x] Syntax check
- [x] Write documentation about `file_movements` (esm-tools/esm_tools#412)
- [x] Merge to `prep_release`