### PR TITLE
prints an explanatory error message if a scenario is not implemented …

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.27"
+__version__ = "5.1.28"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/filelists.py
+++ b/esm_runscripts/filelists.py
@@ -141,7 +141,7 @@ def complete_targets(config):
                             scenario = config[model].get('scenario', 'UNDEFINED')
                             version = config[model].get('version', 'UNDEFINED')
 
-                            error_type = "Missing Scenario Configuration"
+                            error_type = "Missing Configuration"
                             error_text = (
                                 # comment-out the line below to provide more information
                                 # f"Scenario {scenario} for the model {model} (version: {version}) has not been implemented yet. \n" +

--- a/esm_runscripts/filelists.py
+++ b/esm_runscripts/filelists.py
@@ -136,11 +136,15 @@ def complete_targets(config):
                         # check if the file_source has the correct type. For
                         # unresolved variables they may still be a 'dict'
                         if not isinstance(file_source, (str, os.PathLike)):
+                            # model, scenario and version are omitted to make
+                            # error message less verbose
                             scenario = config[model].get('scenario', 'UNDEFINED')
                             version = config[model].get('version', 'UNDEFINED')
+
                             error_type = "Missing Scenario Configuration"
                             error_text = (
-                                f"Scenario {scenario} for the model {model} (version: {version}) has not been implemented yet. \n" +
+                                # comment-out the line below to provide more information
+                                # f"Scenario {scenario} for the model {model} (version: {version}) has not been implemented yet. \n" +
                                 f"The input file variable {categ} of {filetype}_sources can not be fully resolved:\n\n" +
                                 yaml.dump(file_source, indent=4))
                             esm_parser.user_error(error_type, error_text)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.27
+current_version = 5.1.28
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/esm-tools/esm_runscripts',
-    version="5.1.27",
+    version="5.1.28",
     zip_safe=False,
 )


### PR DESCRIPTION
This PR solves the issue https://github.com/esm-tools/esm_runscripts/issues/172

I tested different solutions and finally decided that this one gives the most useful error message to the user. This error message provides the user
- which **model** & **version**,
- which **scenario** and
- which **file type** is causing the problem
- together with the **file source** causing the crash



eg. if you try to run ECHAM with the scenario ` scenario: 1percCO2`, now these lines will be printed:

```
ERROR: Missing Scenario Configuration
-------------------------------------

Scenario 1percCO2 for the model jsbach (version: 3.20p1) has not been implemented yet.
The input file variable LU_HIST of forcing_sources can not be fully resolved:

/work/bb0519/foci_input2/JSBACH/input/r0010/T63/New_Hampshire_LCC/hist_harvest/LUH_harvest_T63_1850.nc:
    to: 1850
/work/bb0519/foci_input2/JSBACH/input/r0010/T63/New_Hampshire_LCC/hist_harvest/LUH_harvest_T63_@YEAR@.nc:
    from: 1851
```

Instead of 
```
Traceback (most recent call last):
  File "/home/shkifmsw/.local/bin/esm_runscripts", line 11, in <module>
    load_entry_point('esm-runscripts', 'console_scripts', 'esm_runscripts')()
  File "/home/shkifmsw/esm/esm_runscripts/esm_runscripts/cli.py", line 202, in main
    Setup()
  File "/home/shkifmsw/esm/esm_runscripts/esm_runscripts/sim_objects.py", line 50, in __call__
    self.compute(*args, **kwargs)
  File "/home/shkifmsw/esm/esm_runscripts/esm_runscripts/sim_objects.py", line 84, in compute
    self.config = compute.run_job(self.config)
  File "/home/shkifmsw/esm/esm_runscripts/esm_runscripts/compute.py", line 32, in run_job
    config = evaluate(config, "compute", "compute_recipe")
  File "/home/shkifmsw/esm/esm_runscripts/esm_runscripts/helpers.py", line 49, in evaluate
    framework_recipe, framework_plugins, config
  File "/home/shkifmsw/.local/lib/python3.7/site-packages/esm_plugin_manager/esm_plugin_manager.py", line 138, in work_through_recipe
    config = getattr(submodule, workitem)(config)
  File "/home/shkifmsw/esm/esm_runscripts/esm_runscripts/filelists.py", line 941, in assemble
    config = complete_targets(config)
  File "/home/shkifmsw/esm/esm_runscripts/esm_runscripts/filelists.py", line 126, in complete_targets
    config[model][filetype + "_sources"][categ]
  File "/sw/tools/python/anaconda3/2019.03/skl/lib/python3.7/posixpath.py", line 146, in basename
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not dict
```

I tried the same hack in other parts of the `esm_runscripts` but did not find anything yet. Maybe someone else will in the future and then we can use the same solution there too.

After the merge and bump, I will merge the `HIST` case stuff.