### PR TITLE
debug_level (NLOGPRT) can now be configured for the namcouple file fo…

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.29"
+__version__ = "5.1.30"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/coupler.py
+++ b/esm_runscripts/coupler.py
@@ -23,6 +23,7 @@ class coupler_class:
             self.norestart = full_config["oasis3mct"].get("norestart", "F")
             self.coupler = oasis.oasis(self.nb_of_couplings, self.coupled_execs, self.runtime,
                                        nnorest=self.norestart, mct_version=full_config["oasis3mct"].get("mct_version", "2.8"),
+                                       debug_level=full_config["oasis3mct"].get("debug_level",1), 
                                        lucia=full_config["oasis3mct"].get("use_lucia", False))
         elif name == "yac":
             from . import yac

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.29
+current_version = 5.1.30
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/esm-tools/esm_runscripts',
-    version="5.1.29",
+    version="5.1.30",
     zip_safe=False,
 )


### PR DESCRIPTION
The NLOGPRT (debug_level) was always set to "1" for OASIS. 
This little fix allows the user to set this in the runscript. 
For example, 
```bash
oasis3mct:
         debug_level: 50 
````
will force OASIS to print all fluxes before and after conservation (e.g. GLBPOS) which is very helpful when debugging a coupled model. 

Note that the Lucia tool must be turned off for this to work. 