### PR TITLE
hotfix/generalization of last minute

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.30"
+__version__ = "5.1.31"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/last_minute.py
+++ b/esm_runscripts/last_minute.py
@@ -42,6 +42,14 @@ def apply_last_minute_changes(config):
         settings = modify_config.get("run_only_modifications", {}).get("batch_system", {}).get("direct_settings")
         _modify_config_with_settings(config, settings)
 
+        for chapter in modify_config:
+            if chapter not in [
+                "build_and_run_modifications",
+                "build_only_modifications",
+                "run_only_modifications",
+            ]:
+                esm_parser.dict_merge(config, modify_config)
+
     return config
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.30
+current_version = 5.1.31
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/esm-tools/esm_runscripts',
-    version="5.1.30",
+    version="5.1.31",
     zip_safe=False,
 )


### PR DESCRIPTION
Generalization of last minute changes so that the file for last minute changes can now also contain standard 'runsript-looking-like' variables. This function is accessed by `esm_master` through the `-m <file.yaml>` flag through a call to `esm_runscripts.SimulationSetup` (https://github.com/esm-tools/esm_master/blob/39e8ae5f741ae36a861372ca0baad6ae5a90dd9b/esm_master/esm_master.py#L52-L54). This option is particularly useful for `esm_master` as it could allow the user to switch for example between MPI configurations, running `esm_master install-<model> -m <file.yaml>` where the file contains:
```
computer:
    useMPI: openmpi
```

**TODO**

- [ ] Document the feature `last_minute_changes` feature
- [x] Test `esm_master`
- [x] Test `esm_runscripts`