### PR TITLE
fix/compute log and error catching

### DIFF
--- a/esm_runscripts/batch_system.py
+++ b/esm_runscripts/batch_system.py
@@ -138,7 +138,7 @@ class batch_system:
             "overcommit_flag"
         ]
         #??? Do we need the exclusive flag?
-        if config["general"]["jobtype"] in ["compute", "tidy"]:
+        if config["general"]["jobtype"] in ["prepcompute", "tidy"]:
             conditional_flags.append("exclusive_flag")
         for flag in conditional_flags:
             if flag in this_batch_system:

--- a/esm_runscripts/inspect.py
+++ b/esm_runscripts/inspect.py
@@ -83,7 +83,7 @@ def inspect_file(config):
     knownfiles = {}
     search_dir = config["general"]["thisrun_dir"]
     if config["general"]["inspect"] == "lastlog":
-        maybe_file = config["computer"]["thisrun_logfile"].replace("%j", "*")
+        maybe_file = config["computer"]["thisrun_logfile"].replace("@jobtype@", "compute")
     elif config["general"]["inspect"] == "explog":
         maybe_file = f"{config['general']['expid']}_{config['general']['setup_name']}.log"
         search_dir = config["general"]["experiment_dir"]

--- a/esm_runscripts/logfiles.py
+++ b/esm_runscripts/logfiles.py
@@ -1,4 +1,4 @@
-import os, sys
+import os, sys, _io
 from . import helpers
 
 def initialize_logfiles(config, org_jobtype):
@@ -22,11 +22,11 @@ def initialize_logfiles(config, org_jobtype):
                 org_jobtype,
                 logfile_run_number,
                 str(config["general"]["current_date"]),
-                str(config["general"]["jobid"]), 
+                str(config["general"]["jobid"]),
                 "- start",
             ],
         )
-        logfile = open(
+        logfile = RuntimeLogger(
             config["general"]["logfile_path"],
             "w",
             buffering=1,
@@ -35,7 +35,7 @@ def initialize_logfiles(config, org_jobtype):
         logfile = sys.stdout
 
     logfile_handle = logfile
-    return config 
+    return config
 
 
 def finalize_logfiles(config, org_jobtype):
@@ -119,4 +119,71 @@ def set_logfile_name(config, jobtype = None):
     #            )
 
     return config
+
+
+class RuntimeLogger(_io.TextIOWrapper):
+    """
+    Logger object that takes care of both, writing the stdout and stderr to the
+    'mini-log' file corresponding to the different elements of the workflow (observe,
+    tidy, ...), and writing to the system stdout/stderr so that it is catched by SLURM
+    (or I guess PBS) and put into the ``*compute*.log`` specified in the ``.sad`` file.
+    The ``*compute*.log`` file is then used to catch errors by ``observe``.
+
+    .. Note: This is a fast and minimal solution for release 6.0, but all this could be done
+    without needing this object, once ``loguru`` is implemented everywhere in some
+    point in the future.
+
+    .. Note: This is a subclass of ``_io.TextIOWrapper`` which is horrible! I could
+    have used simply ``object`` instead, but this was the only way I (MA) found for
+    ``f90nml`` package to be able to print namelists in the following lines of
+    ``namelist.py``::
+        def nmls_output(mconfig):
+            all_nmls = {}
+
+            for nml_name, nml_obj in six.iteritems(mconfig.get("namelists", {})):
+                all_nmls[nml_name] = nml_obj  # PG: or a string representation?
+            for nml_name, nml in all_nmls.items():
+                message = f'\nFinal Contents of {nml_name}:'
+                six.print_(message)
+                six.print_(len(message) * '-')
+                nml.write(sys.stdout)  # Problematic line if the sys.stdout is not a file-like object
+                print('-' * 80)
+                print(f'::: end of the contents of {nml_name}\n')
+            return mconfig
+    Hopefully, we are not using any other methods than the ones specified here...
+    """
+    def __init__(self, *args, **kwargs):
+        """
+        Initializes the logger object, and opens the mini-log file, to be used as a
+        target for ``sys.stdout``::
+            sys.stdout = LogFile(args, kwargs)
+
+        Parameters
+        ----------
+        args, kwargs
+            Use the same parameters as you would with the ``open`` command.
+        """
+        # Direct system's stderr to stdout
+        sys.stderr = sys.stdout
+        # Store the system's stdout as an object
+        self.stdout = sys.stdout
+        # Open the mini-log file
+        self.file_obj = open(*args, **kwargs)
+    def write(self, *args, **kwargs):
+        """
+        Writes messages to the mini-log file and to the system's stdout.
+        """
+        # Write into the mini-log file
+        self.file_obj.write(*args, **kwargs)
+        # Write into the system's stdout (so that it makes it to *compute*.log defined
+        # in the .sad file)
+        self.stdout.write(args[0])
+    def flush(self):
+        pass
+    def close(self, *args, **kwargs):
+        """
+        Closes the mini-log file.
+        """
+        # Close the mini-log file
+        self.file_obj.close(*args, **kwargs)
 

--- a/esm_runscripts/namelists.py
+++ b/esm_runscripts/namelists.py
@@ -156,7 +156,7 @@ class Namelist:
         for remove in namelist_removes:
             namelist, change_chapter, key = remove
             logging.debug("Removing from %s: %s, %s", namelist, change_chapter, key)
-            if key in mconfig["namelists"][namelist][change_chapter]:
+            if key in mconfig["namelists"][namelist].get(change_chapter, {}):
                 del mconfig["namelists"][namelist][change_chapter][key]
         return mconfig
 

--- a/esm_runscripts/observe.py
+++ b/esm_runscripts/observe.py
@@ -26,7 +26,9 @@ def init_monitor_file(config):
         config["general"]["experiment_log_dir"] +
         config["general"]["expid"] +
         "_" +
-        called_from + 
+        config["general"]["setup_name"] +
+        "_" +
+        called_from +
         "_" +
         config["general"]["run_datestamp"] +
         #"_" +
@@ -36,9 +38,11 @@ def init_monitor_file(config):
     log_in_run = (
         config["general"]["thisrun_log_dir"] +
         config["general"]["expid"] +
-        "_" + 
+        "_" +
+        config["general"]["setup_name"] +
+        "_" +
         called_from +
-        #"_" + 
+        #"_" +
         #str(config["general"]["jobid"]) +
         ".log"
     )
@@ -98,8 +102,10 @@ def assemble_error_list(config):
         gconfig["thisrun_log_dir"]
         + "/"
         + gconfig["expid"]
-        + "_compute_"
-        + gconfig["run_datestamp"]
+        + "_"
+        + config["general"]["setup_name"]
+        + "_"
+        + called_from
         #+ "_"
         #+ gconfig["jobid"]
         + ".log"
@@ -173,14 +179,14 @@ def check_for_errors(config):
                                 monitor_file.write("WARNING: " + message + "\n")
                                 break
                             elif method == "kill":
-                                harakiri = "scancel " + config["general"]["jobid"]
+                                cancel_job = f"scancel {config['general']['jobid']}"
                                 monitor_file.write("ERROR: " + message + "\n")
                                 monitor_file.write("Will kill the run now..." + "\n")
                                 monitor_file.flush()
                                 print("ERROR: " + message)
                                 print("Will kill the run now...", flush=True)
                                 database_actions.database_entry_crashed(config)
-                                os.system(harakiri)
+                                os.system(cancel_job)
                                 sys.exit(42)
             next_check += frequency
         if warned == 0:

--- a/esm_runscripts/sim_objects.py
+++ b/esm_runscripts/sim_objects.py
@@ -39,11 +39,13 @@ class SimulationSetup(object):
 
 
     def __call__(self, kill_after_submit=True):
+        # Trigger inspect functionalities
         if self.config["general"]["jobtype"] == "inspect":
             #esm_parser.pprint_config(self.config)
             self.inspect()
             helpers.end_it_all(self.config)
-        
+
+        # Run the preexp recipe
         self.config = prepexp.run_job(self.config)
 
         #self.pseudocall(kill_after_submit)


### PR DESCRIPTION
`stdout` and `stderr` are now both printed to the system's `stdout` (catched by slurm's log file), and into the respective element log file. Errors during runtime are catched again. `#SBATCH --exclusive` back again in the .sad file