### PR TITLE
added LOCCUNIF option for SCRIP - locally conservative remapping suit…

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.31"
+__version__ = "5.1.32"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/oasis.py
+++ b/esm_runscripts/oasis.py
@@ -155,19 +155,19 @@ class oasis:
                 detail_line = mapname + " " + maploc + " " + mapstrat
                 trafo_details.append(detail_line.strip())
 
-            elif trans.lower() in ["distwgt", "bicubic", "bilinear", "gauswgt", "conserv"]:
+            elif trans.lower() in ["distwgt", "bicubic", "bilinear", "gauswgt", "conserv", "loccunif"]:
                 trafo_line += " SCRIPR"
                 srcgridtype = str(rgrid["oasis_grid_type"]).upper()
                 search_bin = transform.get("search_bin", None)
                 if not search_bin:
-                    print ("search_bin (LATITUDE or LATLON) needs to be defined for transformations DISTWGT, GAUSWGT, BILINEAR, BICUBIC", flush=True)
+                    print ("search_bin (LATITUDE or LATLON) needs to be defined for transformations DISTWGT, GAUSWGT, BILINEAR, BICUBIC, LOCCUNIF", flush=True)
                     sys.exit(2)
                 bins = transform.get("nb_of_search_bins", "1")
                 detail_line = trans.upper() + " " + srcgridtype.upper() + " SCALAR " + search_bin.upper() + " " + str(bins)
-                if trans.lower() in ["distwgt", "gauswgt"]:
+                if trans.lower() in ["distwgt", "gauswgt", "loccunif"]:
                     nb_of_neighbours = transform.get("nb_of_neighbours", None)
                     if not nb_of_neighbours:
-                        print ("nb_of_neighbours needs to be defined for transformations DISTWGT and GAUSWGT", flush=True)
+                        print ("nb_of_neighbours needs to be defined for transformations DISTWGT, GAUSWGT and LOCCUNIF", flush=True)
                         sys.exit(2)
                     detail_line += " " + str(nb_of_neighbours)
                 if trans.lower() == "gauswgt":

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.31
+current_version = 5.1.32
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/esm-tools/esm_runscripts',
-    version="5.1.31",
+    version="5.1.32",
     zip_safe=False,
 )


### PR DESCRIPTION
Hey all

I added the LOCCUNIF option for remapping in OASIS. 
This remapping is used to do 1-to-1 locally conserving remapping, suitable for remapping river runoff to ocean models. 

This is just adding a new option. Should not break any existing code. 

Note: LOCCUNIF will be available in OASIS3-MCT5, to be released later this year. 
