### PR TITLE
hotfix/namelist remove var properties

### DIFF
--- a/esm_runscripts/__init__.py
+++ b/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.35"
+__version__ = "5.1.36"
 
 from .sim_objects import *
 from .batch_system import *

--- a/esm_runscripts/namelists.py
+++ b/esm_runscripts/namelists.py
@@ -158,6 +158,11 @@ class Namelist:
             logging.debug("Removing from %s: %s, %s", namelist, change_chapter, key)
             if key in mconfig["namelists"][namelist][change_chapter]:
                 del mconfig["namelists"][namelist][change_chapter][key]
+            elif "%" in key:
+                namvar, prop = key.split("%")
+                del mconfig["namelists"][namelist][change_chapter][namvar][prop]
+            else:
+                logging.debug("Unable to remove %s: %s, %s", namelist, change_chapter, key)
         return mconfig
 
     @staticmethod

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.35
+current_version = 5.1.36
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/esm-tools/esm_runscripts',
-    version="5.1.35",
+    version="5.1.36",
     zip_safe=False,
 )


### PR DESCRIPTION
`remove_from_namelist` can now remove variables with properties such as `YS_NL%LMASSFIX`